### PR TITLE
Sms command unit tests

### DIFF
--- a/tests/Unit/SmsCommand/CommandExecutorTest.php
+++ b/tests/Unit/SmsCommand/CommandExecutorTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\BikeShare\Unit\SmsCommand;
+
+use BikeShare\App\Entity\User;
+use BikeShare\Event\SmsProcessedEvent;
+use BikeShare\SmsCommand\AddCommand;
+use BikeShare\SmsCommand\CommandDetector;
+use BikeShare\SmsCommand\CommandExecutor;
+use BikeShare\SmsCommand\SmsCommandInterface;
+use BikeShare\SmsCommand\Exception\ValidationException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class CommandExecutorTest extends TestCase
+{
+    /** @var CommandDetector|MockObject */
+    private $commandDetectorMock;
+    /** @var ServiceLocator|MockObject */
+    private $commandLocatorMock;
+    /** @var EventDispatcherInterface|MockObject */
+    private $eventDispatcherMock;
+    /** @var TranslatorInterface|MockObject */
+    private $translatorMock;
+    /** @var LoggerInterface|MockObject */
+    private $loggerMock;
+
+    private CommandExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->commandDetectorMock = $this->createMock(CommandDetector::class);
+        $this->commandLocatorMock = $this->createMock(ServiceLocator::class);
+        $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+
+        $this->executor = new CommandExecutor(
+            $this->commandDetectorMock,
+            $this->commandLocatorMock,
+            $this->eventDispatcherMock,
+            $this->translatorMock,
+            $this->loggerMock,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->commandDetectorMock,
+            $this->commandLocatorMock,
+            $this->eventDispatcherMock,
+            $this->translatorMock,
+            $this->loggerMock,
+            $this->executor
+        );
+    }
+
+    public function testExecuteUnknownCommand(): void
+    {
+        $user = $this->createMock(User::class);
+        $possibleCommandMock = $this->createMock(SmsCommandInterface::class);
+
+        $this->commandDetectorMock
+            ->expects($this->once())
+            ->method('detect')
+            ->willReturn(['command' => 'UNKNOWN', 'possibleCommand' => 'ADD', 'arguments' => []]);
+        $this->commandLocatorMock->expects($this->once())->method('has')->with('ADD')->willReturn(true);
+        $this->commandLocatorMock->expects($this->once())->method('get')->with('ADD')->willReturn($possibleCommandMock);
+        $possibleCommandMock->expects($this->once())->method('getHelpMessage')->willReturn('help message');
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Error. More arguments needed, use command {command}', ['command' => 'help message'])
+            ->willReturn('translated error');
+
+        $this->assertEquals('translated error', $this->executor->execute('ADD', $user));
+    }
+
+    public function testExecuteThrowsRuntimeExceptionOnUnknownCommand(): void
+    {
+        $user = $this->createMock(User::class);
+
+        $this->commandDetectorMock
+            ->expects($this->once())
+            ->method('detect')
+            ->willReturn(['command' => 'FOO', 'arguments' => []]);
+        $this->commandLocatorMock->expects($this->once())->method('has')->with('FOO')->willReturn(false);
+        $this->expectException(\RuntimeException::class);
+
+        $this->executor->execute('FOO', $user);
+    }
+
+    public function testExecuteKnownCommand(): void
+    {
+        $user = $this->createMock(User::class);
+        $commandName = 'ADD';
+        $arguments = ['email' => 'test@example.com', 'phone' => '123', 'fullName' => 'Test User'];
+
+        $commandMock = $this->createMock(AddCommand::class);
+        $commandMock->expects($this->once())->method('checkPrivileges')->with($user);
+        $commandMock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($user, ...array_values($arguments))
+            ->willReturn('ok');
+        $this->commandDetectorMock
+            ->expects($this->once())
+            ->method('detect')
+            ->willReturn(['command' => $commandName, 'arguments' => $arguments]);
+        $this->commandLocatorMock->expects($this->once())->method('has')->with($commandName)->willReturn(true);
+        $this->commandLocatorMock->expects($this->once())->method('get')->with($commandName)->willReturn($commandMock);
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(SmsProcessedEvent::class));
+
+        $this->assertEquals('ok', $this->executor->execute('ADD test@example.com 123 Test User', $user));
+    }
+
+    public function testExecuteHandlesValidationException(): void
+    {
+        $user = $this->createMock(User::class);
+        $commandName = 'ADD';
+
+        $commandMock = $this->createMock(AddCommand::class);
+        $commandMock->expects($this->once())->method('checkPrivileges')->with($user);
+        $commandMock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->willThrowException(new ValidationException('validation error'));
+        $this->commandDetectorMock
+            ->expects($this->once())
+            ->method('detect')
+            ->willReturn([
+                'command' => $commandName,
+                'arguments' => ['email' => 'test@example.com', 'phone' => '123', 'fullName' => 'Test User'],
+            ]);
+        $this->commandLocatorMock->expects($this->once())->method('has')->with($commandName)->willReturn(true);
+        $this->commandLocatorMock->expects($this->once())->method('get')->with($commandName)->willReturn($commandMock);
+        $this->loggerMock->expects($this->once())->method('warning');
+
+        $this->assertEquals('validation error', $this->executor->execute('ADD test@example.com 123 Test User', $user));
+    }
+
+    public function testExecuteHandlesGenericException(): void
+    {
+        $user = $this->createMock(User::class);
+        $commandName = 'ADD';
+
+        $commandMock = $this->createMock(AddCommand::class);
+        $commandMock->expects($this->once())->method('checkPrivileges')->with($user);
+        $commandMock->expects($this->once())->method('__invoke')->willThrowException(new \Exception('fail'));
+        $this->commandDetectorMock
+            ->expects($this->once())
+            ->method('detect')
+            ->willReturn([
+                'command' => $commandName,
+                'arguments' => ['email' => 'test@example.com', 'phone' => '123', 'fullName' => 'Test User'],
+            ]);
+        $this->commandLocatorMock->expects($this->once())->method('has')->with($commandName)->willReturn(true);
+        $this->commandLocatorMock->expects($this->once())->method('get')->with($commandName)->willReturn($commandMock);
+        $this->loggerMock->expects($this->once())->method('error');
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('An error occurred while processing your request.')
+            ->willReturn('generic error');
+
+        $this->assertEquals('generic error', $this->executor->execute('ADD test@example.com 123 Test User', $user));
+    }
+}

--- a/tests/Unit/SmsCommand/NoteCommandTest.php
+++ b/tests/Unit/SmsCommand/NoteCommandTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\BikeShare\Unit\SmsCommand;
+
+use BikeShare\App\Entity\User;
+use BikeShare\Repository\BikeRepository;
+use BikeShare\Repository\NoteRepository;
+use BikeShare\Repository\StandRepository;
+use BikeShare\SmsCommand\Exception\ValidationException;
+use BikeShare\SmsCommand\NoteCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class NoteCommandTest extends TestCase
+{
+    /** @var TranslatorInterface|MockObject */
+    private $translatorMock;
+    /** @var BikeRepository|MockObject */
+    private $bikeRepositoryMock;
+    /** @var StandRepository|MockObject */
+    private $standRepositoryMock;
+    /** @var NoteRepository|MockObject */
+    private $noteRepositoryMock;
+
+    private NoteCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
+        $this->bikeRepositoryMock = $this->createMock(BikeRepository::class);
+        $this->standRepositoryMock = $this->createMock(StandRepository::class);
+        $this->noteRepositoryMock = $this->createMock(NoteRepository::class);
+
+        $this->command = new NoteCommand(
+            $this->translatorMock,
+            $this->bikeRepositoryMock,
+            $this->standRepositoryMock,
+            $this->noteRepositoryMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->translatorMock,
+            $this->bikeRepositoryMock,
+            $this->standRepositoryMock,
+            $this->noteRepositoryMock,
+            $this->command
+        );
+    }
+
+    public function testAddBikeNoteSuccess(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserId')->willReturn(1);
+        $bikeNumber = 42;
+        $note = 'Flat tire';
+
+        $this->bikeRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($bikeNumber)
+            ->willReturn(['bikeNumber' => $bikeNumber]);
+        $this->noteRepositoryMock->expects($this->once())->method('addNoteToBike')->with($bikeNumber, 1, $note);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Note "{note}" for bike {bikeNumber} saved.', ['note' => $note, 'bikeNumber' => $bikeNumber])
+            ->willReturn('Note "Flat tire" for bike 42 saved.');
+
+        $this->assertEquals('Note "Flat tire" for bike 42 saved.', ($this->command)($user, $bikeNumber, null, $note));
+    }
+
+    public function testAddBikeNoteEmptyNoteThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $bikeNumber = 42;
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'Empty note for bike {bikeNumber} not saved, for deleting notes use DELNOTE (for admins).',
+                ['bikeNumber' => $bikeNumber]
+            )
+            ->willReturn('Empty note for bike 42 not saved.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Empty note for bike 42 not saved.');
+
+        ($this->command)($user, $bikeNumber, null, '');
+    }
+
+    public function testAddBikeNoteBikeNotFoundThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $bikeNumber = 99;
+
+        $this->bikeRepositoryMock->expects($this->once())->method('findItem')->with($bikeNumber)->willReturn([]);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Bike {bikeNumber} does not exist.', ['bikeNumber' => $bikeNumber])
+            ->willReturn('Bike 99 does not exist.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Bike 99 does not exist.');
+
+        ($this->command)($user, $bikeNumber, null, 'Broken chain');
+    }
+
+    public function testAddStandNoteSuccess(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserId')->willReturn(2);
+        $stand = 'STAND1';
+        $note = 'No bikes available';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($stand)
+            ->willReturn(['standId' => 5]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('addNoteToStand')
+            ->with(5, 2, $note);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Note "{note}" for stand {standName} saved.', ['note' => $note, 'standName' => $stand])
+            ->willReturn('Note "No bikes available" for stand STAND1 saved.');
+
+        $this->assertEquals(
+            'Note "No bikes available" for stand STAND1 saved.',
+            ($this->command)($user, null, $stand, $note),
+        );
+    }
+
+    public function testAddStandNoteEmptyNoteThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'STAND1';
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'Empty note for stand {standName} not saved, for deleting notes use DELNOTE (for admins).',
+                ['standName' => $stand]
+            )
+            ->willReturn('Empty note for stand STAND1 not saved.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Empty note for stand STAND1 not saved.');
+
+        ($this->command)($user, null, $stand, '');
+    }
+
+    public function testAddStandNoteInvalidStandNameThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'stand#1';
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'Stand name {standName} has not been recognized. Stands are marked by CAPITALLETTERS.',
+                ['standName' => $stand]
+            )
+            ->willReturn('Stand name stand#1 has not been recognized.');
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Stand name stand#1 has not been recognized.');
+
+        ($this->command)($user, null, $stand, 'Something wrong');
+    }
+
+    public function testAddStandNoteStandNotFoundThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'STAND2';
+
+        $this->standRepositoryMock->expects($this->once())->method('findItemByName')->with($stand)->willReturn(null);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Stand {standName} does not exist.', ['standName' => $stand])
+            ->willReturn('Stand STAND2 does not exist.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Stand STAND2 does not exist.');
+
+        ($this->command)($user, null, $stand, 'No lock');
+    }
+
+    public function testInvokeWithNoBikeOrStandThrows(): void
+    {
+        $user = $this->createMock(User::class);
+
+        $this->translatorMock
+            ->expects($this->exactly(2))
+            ->method('trans')
+            ->withConsecutive(
+                ['Flat tire on front wheel'],
+                ['with bike number/stand name and problem description: {example}']
+            )
+            ->willReturnOnConsecutiveCalls('Flat tire on front wheel', 'Help message');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Help message');
+
+        ($this->command)($user);
+    }
+
+    public function testGetHelpMessage(): void
+    {
+        $this->translatorMock
+            ->expects($this->exactly(2))
+            ->method('trans')
+            ->withConsecutive(
+                ['Flat tire on front wheel'],
+                [
+                    'with bike number/stand name and problem description: {example}',
+                    ['example' => 'NOTE 42 Flat tire on front wheel']
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                'Flat tire on front wheel',
+                'with bike number/stand name and problem description: NOTE 42 Flat tire on front wheel'
+            );
+
+        $this->assertEquals(
+            'with bike number/stand name and problem description: NOTE 42 Flat tire on front wheel',
+            $this->command->getHelpMessage()
+        );
+    }
+}

--- a/tests/Unit/SmsCommand/TagCommandTest.php
+++ b/tests/Unit/SmsCommand/TagCommandTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\BikeShare\Unit\SmsCommand;
+
+use BikeShare\App\Entity\User;
+use BikeShare\Repository\NoteRepository;
+use BikeShare\Repository\StandRepository;
+use BikeShare\SmsCommand\Exception\ValidationException;
+use BikeShare\SmsCommand\TagCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TagCommandTest extends TestCase
+{
+    /** @var TranslatorInterface|MockObject */
+    private $translatorMock;
+    /** @var StandRepository|MockObject */
+    private $standRepositoryMock;
+    /** @var NoteRepository|MockObject */
+    private $noteRepositoryMock;
+
+    private TagCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
+        $this->standRepositoryMock = $this->createMock(StandRepository::class);
+        $this->noteRepositoryMock = $this->createMock(NoteRepository::class);
+
+        $this->command = new TagCommand($this->translatorMock, $this->standRepositoryMock, $this->noteRepositoryMock);
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->translatorMock,
+            $this->standRepositoryMock,
+            $this->noteRepositoryMock,
+            $this->command
+        );
+    }
+
+    public function testTagStandSuccess(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserId')->willReturn(10);
+        $standName = 'MAINSTAND';
+        $note = 'vandalism';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($standName)
+            ->willReturn(['standId' => 5]);
+        $this->noteRepositoryMock->expects($this->once())->method('addNoteToAllBikesOnStand')->with(5, 10, $note);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'All bikes on stand {standName} tagged with note "{note}".',
+                ['standName' => $standName, 'note' => $note]
+            )
+            ->willReturn('All bikes on stand MAINSTAND tagged with note "vandalism".');
+
+        $this->assertEquals(
+            'All bikes on stand MAINSTAND tagged with note "vandalism".',
+            ($this->command)($user, $standName, $note)
+        );
+    }
+
+    public function testTagStandEmptyNoteThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $standName = 'MAINSTAND';
+        $message = 'Empty tag for stand {standName} not saved, '
+            . 'for deleting notes for all bikes on stand use UNTAG (for admins).';
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with($message, ['standName' => $standName])
+            ->willReturn('Empty tag for stand MAINSTAND not saved.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Empty tag for stand MAINSTAND not saved.');
+
+        ($this->command)($user, $standName, '');
+    }
+
+    public function testTagStandInvalidStandNameThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $standName = 'stand#1';
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'Stand name {standName} has not been recognized. Stands are marked by CAPITALLETTERS.',
+                ['standName' => $standName]
+            )
+            ->willReturn('Stand name stand#1 has not been recognized.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Stand name stand#1 has not been recognized.');
+
+        ($this->command)($user, $standName, 'vandalism');
+    }
+
+    public function testTagStandNotFoundThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $standName = 'UNKNOWNSTAND';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($standName)->willReturn(null);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Stand {standName} does not exist.', ['standName' => $standName])
+            ->willReturn('Stand UNKNOWNSTAND does not exist.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Stand UNKNOWNSTAND does not exist.');
+
+        ($this->command)($user, $standName, 'vandalism');
+    }
+
+    public function testGetHelpMessage(): void
+    {
+        $this->translatorMock
+            ->expects($this->exactly(2))
+            ->method('trans')
+            ->withConsecutive(
+                ['vandalism'],
+                ['with stand name and problem description: {example}', ['example' => 'TAG MAINSQUARE vandalism']],
+            )
+            ->willReturnOnConsecutiveCalls(
+                'vandalism',
+                'with stand name and problem description: TAG MAINSQUARE vandalism'
+            );
+
+        $this->assertEquals(
+            'with stand name and problem description: TAG MAINSQUARE vandalism',
+            $this->command->getHelpMessage()
+        );
+    }
+}

--- a/tests/Unit/SmsCommand/UnTagCommandTest.php
+++ b/tests/Unit/SmsCommand/UnTagCommandTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\BikeShare\Unit\SmsCommand;
+
+use BikeShare\App\Entity\User;
+use BikeShare\Repository\NoteRepository;
+use BikeShare\Repository\StandRepository;
+use BikeShare\SmsCommand\Exception\ValidationException;
+use BikeShare\SmsCommand\UnTagCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class UnTagCommandTest extends TestCase
+{
+    /** @var TranslatorInterface|MockObject */
+    private $translatorMock;
+    /** @var StandRepository|MockObject */
+    private $standRepositoryMock;
+    /** @var NoteRepository|MockObject */
+    private $noteRepositoryMock;
+
+    private UnTagCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
+        $this->standRepositoryMock = $this->createMock(StandRepository::class);
+        $this->noteRepositoryMock = $this->createMock(NoteRepository::class);
+
+        $this->command = new UnTagCommand(
+            $this->translatorMock,
+            $this->standRepositoryMock,
+            $this->noteRepositoryMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->translatorMock,
+            $this->standRepositoryMock,
+            $this->noteRepositoryMock,
+            $this->command
+        );
+    }
+
+    public function testUnTagStandSuccessNoPattern(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'MAINSQUARE';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($stand)
+            ->willReturn(['standId' => 5]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('deleteNotesForAllBikesOnStand')
+            ->with(5, '')
+            ->willReturn(3);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                '{count} notes matching pattern "{pattern}" for bikes on stand {standName} were deleted.',
+                ['standName' => $stand, 'count' => 3, 'pattern' => '']
+            )
+            ->willReturn('All 3 notes for bikes on stand MAINSQUARE were deleted.');
+
+        $this->assertEquals(
+            'All 3 notes for bikes on stand MAINSQUARE were deleted.',
+            ($this->command)($user, $stand, '')
+        );
+    }
+
+    public function testUnTagStandSuccessWithPattern(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'MAINSQUARE';
+        $pattern = 'vandalism';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($stand)
+            ->willReturn(['standId' => 5]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('deleteNotesForAllBikesOnStand')
+            ->with(5, $pattern)
+            ->willReturn(2);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                '{count} notes matching pattern "{pattern}" for bikes on stand {standName} were deleted.',
+                ['pattern' => $pattern, 'standName' => $stand, 'count' => 2]
+            )
+            ->willReturn('2 notes matching pattern "vandalism" for bikes on stand MAINSQUARE were deleted.');
+
+        $this->assertEquals(
+            '2 notes matching pattern "vandalism" for bikes on stand MAINSQUARE were deleted.',
+            ($this->command)($user, $stand, $pattern)
+        );
+    }
+
+    public function testUnTagStandInvalidStandNameThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'stand#1';
+
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'Stand name {standName} has not been recognized. Stands are marked by CAPITALLETTERS.',
+                ['standName' => $stand]
+            )
+            ->willReturn('Stand name stand#1 has not been recognized.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Stand name stand#1 has not been recognized.');
+
+        ($this->command)($user, $stand);
+    }
+
+    public function testUnTagStandNotFoundThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'UNKNOWNSTAND';
+
+        $this->standRepositoryMock->expects($this->once())->method('findItemByName')->with($stand)->willReturn(null);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Stand {standName} does not exist.', ['standName' => $stand])
+            ->willReturn('Stand UNKNOWNSTAND does not exist.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Stand UNKNOWNSTAND does not exist.');
+
+        ($this->command)($user, $stand);
+    }
+
+    public function testUnTagStandNoNotesFoundThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'MAINSQUARE';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($stand)
+            ->willReturn(['standId' => 5]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('deleteNotesForAllBikesOnStand')
+            ->with(5, '')
+            ->willReturn(0);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'No notes matching pattern "{pattern}" found for bikes on stand {standName} to delete.',
+                ['standName' => $stand, 'pattern' => '']
+            )
+            ->willReturn('No bikes with notes found for stand MAINSQUARE to delete.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('No bikes with notes found for stand MAINSQUARE to delete.');
+
+        ($this->command)($user, $stand, '');
+    }
+
+    public function testUnTagStandNoNotesFoundWithPatternThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $stand = 'MAINSQUARE';
+        $pattern = 'vandalism';
+
+        $this->standRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByName')
+            ->with($stand)
+            ->willReturn(['standId' => 5]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('deleteNotesForAllBikesOnStand')
+            ->with(5, $pattern)
+            ->willReturn(0);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'No notes matching pattern "{pattern}" found for bikes on stand {standName} to delete.',
+                ['standName' => $stand, 'pattern' => $pattern]
+            )
+            ->willReturn('No notes matching pattern "vandalism" found for bikes on stand MAINSQUARE to delete.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage(
+            'No notes matching pattern "vandalism" found for bikes on stand MAINSQUARE to delete.'
+        );
+
+        ($this->command)($user, $stand, $pattern);
+    }
+
+    public function testGetHelpMessage(): void
+    {
+        $this->translatorMock->expects($this->exactly(2))
+            ->method('trans')
+            ->withConsecutive(
+                ['vandalism'],
+                [
+                    'with stand name and optional pattern. ' .
+                    'All notes matching pattern will be deleted for all bikes on that stand: {example}',
+                    ['example' => 'UNTAG MAINSQUARE vandalism'],
+                ]
+            )
+            ->willReturnOnConsecutiveCalls(
+                'vandalism',
+                'with stand name and optional pattern. ' .
+                'All notes matching pattern will be deleted for all bikes on that stand: UNTAG MAINSQUARE vandalism'
+            );
+
+        $this->assertEquals(
+            'with stand name and optional pattern. ' .
+            'All notes matching pattern will be deleted for all bikes on that stand: UNTAG MAINSQUARE vandalism',
+            $this->command->getHelpMessage()
+        );
+    }
+}

--- a/tests/Unit/SmsCommand/WhereCommandTest.php
+++ b/tests/Unit/SmsCommand/WhereCommandTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\BikeShare\Unit\SmsCommand;
+
+use BikeShare\App\Entity\User;
+use BikeShare\Repository\BikeRepository;
+use BikeShare\Repository\NoteRepository;
+use BikeShare\SmsCommand\Exception\ValidationException;
+use BikeShare\SmsCommand\WhereCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class WhereCommandTest extends TestCase
+{
+    /** @var TranslatorInterface|MockObject */
+    private $translatorMock;
+    /** @var BikeRepository|MockObject */
+    private $bikeRepositoryMock;
+    /** @var NoteRepository|MockObject */
+    private $noteRepositoryMock;
+
+    private WhereCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
+        $this->bikeRepositoryMock = $this->createMock(BikeRepository::class);
+        $this->noteRepositoryMock = $this->createMock(NoteRepository::class);
+
+        $this->command = new WhereCommand(
+            $this->translatorMock,
+            $this->bikeRepositoryMock,
+            $this->noteRepositoryMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->translatorMock,
+            $this->bikeRepositoryMock,
+            $this->noteRepositoryMock,
+            $this->command
+        );
+    }
+
+    public function testBikeAtStand(): void
+    {
+        $user = $this->createMock(User::class);
+        $bikeNumber = 42;
+
+        $this->bikeRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($bikeNumber)
+            ->willReturn(['bikeNumber' => $bikeNumber]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('findBikeNote')
+            ->with($bikeNumber)
+            ->willReturn([['note' => 'Flat tire']]);
+        $this->bikeRepositoryMock
+            ->expects($this->once())
+            ->method('findBikeCurrentUsage')
+            ->with($bikeNumber)
+            ->willReturn([
+                'number' => '123456789',
+                'userName' => null,
+                'standName' => 'STAND1',
+            ]);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with(
+                'Bike {bikeNumber} is at stand {standName}. {note}',
+                ['bikeNumber' => $bikeNumber, 'standName' => 'STAND1', 'note' => 'Flat tire']
+            )
+            ->willReturn('Bike 42 is at stand STAND1. Flat tire');
+
+        $this->assertEquals('Bike 42 is at stand STAND1. Flat tire', ($this->command)($user, $bikeNumber));
+    }
+
+    public function testBikeRented(): void
+    {
+        $user = $this->createMock(User::class);
+        $bikeNumber = 42;
+
+        $this->bikeRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($bikeNumber)
+            ->willReturn(['bikeNumber' => $bikeNumber]);
+        $this->noteRepositoryMock
+            ->expects($this->once())
+            ->method('findBikeNote')
+            ->with($bikeNumber)
+            ->willReturn([['note' => 'Broken chain']]);
+        $this->bikeRepositoryMock
+            ->expects($this->once())
+            ->method('findBikeCurrentUsage')
+            ->with($bikeNumber)->willReturn([
+                'number' => '987654321',
+                'userName' => 'John Doe',
+                'standName' => null
+            ]);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Bike {bikeNumber} is rented by {userName} (+{phone}). {note}', [
+                'bikeNumber' => $bikeNumber,
+                'userName' => 'John Doe',
+                'phone' => '987654321',
+                'note' => 'Broken chain'
+            ])
+            ->willReturn('Bike 42 is rented by John Doe (+987654321). Broken chain');
+
+        $this->assertEquals(
+            'Bike 42 is rented by John Doe (+987654321). Broken chain',
+            ($this->command)($user, $bikeNumber)
+        );
+    }
+
+    public function testBikeNotFoundThrows(): void
+    {
+        $user = $this->createMock(User::class);
+        $bikeNumber = 42;
+
+        $this->bikeRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($bikeNumber)
+            ->willReturn([]);
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('Bike {bikeNumber} does not exist.', ['bikeNumber' => $bikeNumber])
+            ->willReturn('Bike 42 does not exist.');
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Bike 42 does not exist.');
+
+        ($this->command)($user, $bikeNumber);
+    }
+
+    public function testGetHelpMessage(): void
+    {
+        $this->translatorMock
+            ->expects($this->once())
+            ->method('trans')
+            ->with('with bike number: {example}', ['example' => 'WHERE 42'])
+            ->willReturn('with bike number: WHERE 42');
+
+        $this->assertEquals('with bike number: WHERE 42', $this->command->getHelpMessage());
+    }
+}


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
• Add comprehensive unit tests for SMS command system
• Test command executor with validation and error handling
• Cover note, tag, untag, and where command functionality
• Include edge cases and exception scenarios


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandExecutorTest.php</strong><dd><code>Command executor unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/SmsCommand/CommandExecutorTest.php

• Tests command detection and execution flow<br> • Validates error <br>handling for unknown commands<br> • Tests validation and generic exception <br>handling<br> • Verifies event dispatching on successful execution


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/241/files#diff-49b552a697e6d4c579012e69621f7a5dd290cb886c8b499f11c5b2abcab24464">+178/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NoteCommandTest.php</strong><dd><code>Note command unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/SmsCommand/NoteCommandTest.php

• Tests adding notes to bikes and stands<br> • Validates empty note and <br>invalid entity handling<br> • Tests entity existence validation<br> • Covers <br>help message generation


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/241/files#diff-849414ac78a1db039b361526d22f2863e348597408567b9dd3eb759a70488671">+238/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TagCommandTest.php</strong><dd><code>Tag command unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/SmsCommand/TagCommandTest.php

• Tests tagging all bikes on a stand with notes<br> • Validates stand name <br>format and existence<br> • Tests empty note validation<br> • Covers help <br>message functionality


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/241/files#diff-07a6f8d5f30fab369b2e03b8ec559c02e4467c340b3534f5101c0e17c8684080">+150/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UnTagCommandTest.php</strong><dd><code>UnTag command unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/SmsCommand/UnTagCommandTest.php

• Tests removing notes from bikes on stands<br> • Validates pattern <br>matching for note deletion<br> • Tests stand validation and note existence<br> <br>• Covers help message generation


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/241/files#diff-4c05d750018bf9b3586ee642a0a2008127c476c9cb8f084dbaf8342542bbbb53">+232/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>WhereCommandTest.php</strong><dd><code>Where command unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Unit/SmsCommand/WhereCommandTest.php

• Tests bike location lookup functionality<br> • Validates bike at stand <br>vs rented scenarios<br> • Tests bike existence validation<br> • Covers help <br>message generation


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/241/files#diff-2b58dcb9353a4a6a6f763a26ccf7d83c13b5ca58394851c73b9528c5a45a3d50">+157/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>