### PR TITLE
Refactor rent system result into DTO and enum

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -74,6 +74,8 @@ return static function (ContainerConfigurator $container): void {
             '../src/Event',
             '../src/Command/LoadFixturesCommand.php',
             '../src/SmsCommand/*Command.php',
+            '../src/Rent/DTO',
+            '../src/Rent/Enum',
         ]);
 
     $services->get(\BikeShare\App\Security\ApiTokenAuthenticator::class)
@@ -111,7 +113,10 @@ return static function (ContainerConfigurator $container): void {
         ->bind('$commandLocator', tagged_locator('smsCommand', null, 'getName'));
 
     $services->load('BikeShare\\SmsCommand\\', '../src/SmsCommand/*Command.php')
-        ->bind(RentSystemInterface::class, expr('service("BikeShare\\\Rent\\\RentSystemFactory").getRentSystem("sms")'))
+        ->bind(
+            RentSystemInterface::class,
+            expr('service("BikeShare\\\Rent\\\RentSystemFactory").getRentSystem(constant("BikeShare\\\\Rent\\\\Enum\\\\RentSystemType::SMS"))')
+        )
         ->bind('$forceStack', env('bool:FORCE_STACK'))
     ;
 
@@ -164,6 +169,10 @@ return static function (ContainerConfigurator $container): void {
         ->bind('$violationFee', env('float:CREDIT_SYSTEM_VIOLATION_FEE'));
 
     $services->load('BikeShare\\Rent\\', '../src/Rent')
+        ->exclude([
+            '../src/Rent/DTO',
+            '../src/Rent/Enum',
+        ])
         ->bind(
             '$watchesConfig',
             [

--- a/src/App/DependencyInjection/RentSystemCompilerPass.php
+++ b/src/App/DependencyInjection/RentSystemCompilerPass.php
@@ -19,7 +19,7 @@ class RentSystemCompilerPass implements CompilerPassInterface
 
         $rentSystems = [];
         foreach (array_keys($rentSystemServiceIds) as $id) {
-            $rentSystems[$id::getType()] = new Reference($id);
+            $rentSystems[$id::getType()->value] = new Reference($id);
         }
 
         $factory->setArgument('$locator', ServiceLocatorTagPass::register($container, $rentSystems, 'rentSystems'));

--- a/src/Controller/Api/BikeController.php
+++ b/src/Controller/Api/BikeController.php
@@ -6,6 +6,7 @@ namespace BikeShare\Controller\Api;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\Action;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\HistoryRepository;
@@ -83,7 +84,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->rentBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->rentBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber
         );
@@ -109,7 +110,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->returnBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->returnBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
             $standName,
@@ -135,7 +136,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->rentBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->rentBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
             true // Force rent
@@ -162,7 +163,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->returnBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->returnBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
             $standName,
@@ -236,7 +237,7 @@ class BikeController extends AbstractController
             return $this->json([], Response::HTTP_BAD_REQUEST);
         }
 
-        $response = $rentSystemFactory->getRentSystem('web')->revertBike(
+        $response = $rentSystemFactory->getRentSystem(RentSystemType::WEB)->revertBike(
             $this->getUser()->getUserId(),
             (int)$bikeNumber,
         );

--- a/src/Controller/ScanController.php
+++ b/src/Controller/ScanController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Controller;
 
 use BikeShare\Db\DbInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -44,15 +45,15 @@ class ScanController extends AbstractController
             && $request->request->has('rent')
             && $request->request->get('rent') === "yes"
         ) {
-            $rentSystem = $this->rentSystemFactory->getRentSystem('qr');
+            $rentSystem = $this->rentSystemFactory->getRentSystem(RentSystemType::QR);
             $result = $rentSystem->rentBike($this->getUser()->getUserId(), $bikeNumber);
-            if ($result['error']) {
-                $error = $result['message'];
+            if ($result->isError()) {
+                $error = $result->getMessage();
             } else {
-                $message = $result['message'];
+                $message = $result->getMessage();
             }
 
-            $this->logResponse($result['message']);
+            $this->logResponse($result->getMessage());
         }
 
         return $this->render('scan/rent.html.twig', [
@@ -73,15 +74,15 @@ class ScanController extends AbstractController
         if (empty($stand)) {
             $error = $this->translator->trans('Stand {standName} does not exist.', ['standName' => $standName]);
         } else {
-            $rentSystem = $this->rentSystemFactory->getRentSystem('qr');
+            $rentSystem = $this->rentSystemFactory->getRentSystem(RentSystemType::QR);
             $result = $rentSystem->returnBike($this->getUser()->getUserId(), 0, $standName);
-            if ($result['error']) {
-                $error = $result['message'];
+            if ($result->isError()) {
+                $error = $result->getMessage();
             } else {
-                $message = $result['message'];
+                $message = $result->getMessage();
             }
 
-            $this->logResponse($result['message']);
+            $this->logResponse($result->getMessage());
         }
 
         return $this->render('scan/return.html.twig', [

--- a/src/Rent/AbstractRentSystem.php
+++ b/src/Rent/AbstractRentSystem.php
@@ -452,7 +452,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
 
     protected function createResult(bool $error, string $message, string $code, array $params = []): RentSystemResult
     {
-        return new RentSystemResult($error, $this->normalizeMessage($message), $code, $params, static::getType());
+        return new RentSystemResult($error, $this->normalizeMessage($message), $code, static::getType(), $params);
     }
 
     protected function normalizeMessage(string $message): string

--- a/src/Rent/DTO/RentSystemResult.php
+++ b/src/Rent/DTO/RentSystemResult.php
@@ -12,8 +12,8 @@ class RentSystemResult implements \JsonSerializable
         private readonly bool $error,
         private readonly string $message,
         private readonly string $code,
-        private readonly array $params = [],
         private readonly RentSystemType $systemType,
+        private readonly array $params = [],
     ) {
         if (trim($this->message) === '') {
             throw new \InvalidArgumentException('message cannot be empty.');
@@ -56,7 +56,6 @@ class RentSystemResult implements \JsonSerializable
             'message' => $this->message,
             'code' => $this->code,
             'params' => $this->params,
-            'systemType' => $this->systemType->value,
         ];
     }
 }

--- a/src/Rent/DTO/RentSystemResult.php
+++ b/src/Rent/DTO/RentSystemResult.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Rent\DTO;
+
+use BikeShare\Rent\Enum\RentSystemType;
+
+class RentSystemResult implements \JsonSerializable
+{
+    public function __construct(
+        private readonly bool $error,
+        private readonly string $message,
+        private readonly string $code,
+        private readonly array $params = [],
+        private readonly RentSystemType $systemType,
+    ) {
+        if (trim($this->message) === '') {
+            throw new \InvalidArgumentException('message cannot be empty.');
+        }
+
+        if (trim($this->code) === '') {
+            throw new \InvalidArgumentException('code cannot be empty.');
+        }
+    }
+
+    public function isError(): bool
+    {
+        return $this->error;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    public function getSystemType(): RentSystemType
+    {
+        return $this->systemType;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'error' => $this->error,
+            'message' => $this->message,
+            'code' => $this->code,
+            'params' => $this->params,
+            'systemType' => $this->systemType->value,
+        ];
+    }
+}

--- a/src/Rent/Enum/RentSystemType.php
+++ b/src/Rent/Enum/RentSystemType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Rent\Enum;
+
+enum RentSystemType: string
+{
+    case WEB = 'web';
+    case SMS = 'sms';
+    case QR = 'qr';
+}

--- a/src/Rent/RentSystemFactory.php
+++ b/src/Rent/RentSystemFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class RentSystemFactory
@@ -13,10 +14,10 @@ class RentSystemFactory
     ) {
     }
 
-    public function getRentSystem(string $type): RentSystemInterface
+    public function getRentSystem(RentSystemType $type): RentSystemInterface
     {
-        if ($this->locator->has($type)) {
-            return $this->locator->get($type);
+        if ($this->locator->has($type->value)) {
+            return $this->locator->get($type->value);
         }
 
         throw new \InvalidArgumentException('Invalid rent system type');

--- a/src/Rent/RentSystemInterface.php
+++ b/src/Rent/RentSystemInterface.php
@@ -2,13 +2,16 @@
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
+
 interface RentSystemInterface
 {
-    public function rentBike($userId, $bikeId, $force = false);
+    public function rentBike($userId, $bikeId, $force = false): RentSystemResult;
 
-    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false);
+    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false): RentSystemResult;
 
-    public function revertBike($userId, $bikeId);
+    public function revertBike($userId, $bikeId): RentSystemResult;
 
-    public static function getType(): string;
+    public static function getType(): RentSystemType;
 }

--- a/src/Rent/RentSystemQR.php
+++ b/src/Rent/RentSystemQR.php
@@ -2,19 +2,22 @@
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
+
 /**
  * @phpcs:disable Generic.Files.LineLength
  */
 class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
 {
-    public function rentBike($userId, $bikeId, $force = false)
+    public function rentBike($userId, $bikeId, $force = false): RentSystemResult
     {
         $force = false; #rent by qr code cannot be forced
 
         return parent::rentBike($userId, $bikeId, $force);
     }
 
-    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false)
+    public function returnBike($userId, $bikeId, $standName, $note = '', $force = false): RentSystemResult
     {
         $force = false; #return by qr code cannot be forced
         $note = ''; #note cannot be provided via qr code
@@ -22,9 +25,8 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
         if ($bikeId !== 0) {
             $this->logger->error("Bike number could not be provided via QR code", ["userId" => $userId]);
 
-            return $this->response(
+            return $this->error(
                 $this->translator->trans('Invalid bike number'),
-                self::ERROR,
                 'bike.return.error.invalid_bike_number'
             );
         }
@@ -33,9 +35,8 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
         $bikeNumber = $result->rowCount();
 
         if ($bikeNumber === 0) {
-            return $this->response(
+            return $this->error(
                 $this->translator->trans('You currently have no rented bikes.'),
-                self::ERROR,
                 'bike.return.error.no_rented_bikes'
             );
         } elseif ($bikeNumber > 1) {
@@ -50,9 +51,8 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
                 );
             }
 
-            return $this->response(
+            return $this->error(
                 $message,
-                self::ERROR,
                 'bike.return.error.multiple_rented_bikes',
                 ['bikeNumber' => $bikeNumber],
             );
@@ -63,17 +63,16 @@ class RentSystemQR extends AbstractRentSystem implements RentSystemInterface
         return parent::returnBike($userId, $bikeId, $standName, $note, $force);
     }
 
-    public function revertBike($userId, $bikeId)
+    public function revertBike($userId, $bikeId): RentSystemResult
     {
-        return $this->response(
+        return $this->error(
             $this->translator->trans('Revert is not supported for QR code'),
-            self::ERROR,
             'bike.revert.error.not_supported'
         );
     }
 
-    public static function getType(): string
+    public static function getType(): RentSystemType
     {
-        return 'qr';
+        return RentSystemType::QR;
     }
 }

--- a/src/Rent/RentSystemSms.php
+++ b/src/Rent/RentSystemSms.php
@@ -4,20 +4,17 @@ declare(strict_types=1);
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\Enum\RentSystemType;
+
 class RentSystemSms extends AbstractRentSystem implements RentSystemInterface
 {
-    public static function getType(): string
+    public static function getType(): RentSystemType
     {
-        return 'sms';
+        return RentSystemType::SMS;
     }
 
-    protected function response($message, $error = 0, string $code = '', array $params = []): array
+    protected function normalizeMessage(string $message): string
     {
-        return [
-            'error' => $error,
-            'message' => strip_tags($message),
-            'code' => $code,
-            'params' => $params,
-        ];
+        return strip_tags($message);
     }
 }

--- a/src/Rent/RentSystemWeb.php
+++ b/src/Rent/RentSystemWeb.php
@@ -2,10 +2,12 @@
 
 namespace BikeShare\Rent;
 
+use BikeShare\Rent\Enum\RentSystemType;
+
 class RentSystemWeb extends AbstractRentSystem implements RentSystemInterface
 {
-    public static function getType(): string
+    public static function getType(): RentSystemType
     {
-        return 'web';
+        return RentSystemType::WEB;
     }
 }

--- a/src/SmsCommand/ForceRentCommand.php
+++ b/src/SmsCommand/ForceRentCommand.php
@@ -24,7 +24,7 @@ class ForceRentCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->rentBike($user->getUserId(), $bikeNumber, true);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/ForceReturnCommand.php
+++ b/src/SmsCommand/ForceReturnCommand.php
@@ -24,7 +24,7 @@ class ForceReturnCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->returnBike($user->getUserId(), $bikeNumber, $standName, $note, true);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/RentCommand.php
+++ b/src/SmsCommand/RentCommand.php
@@ -23,7 +23,7 @@ class RentCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->rentBike($user->getUserId(), $bikeNumber);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/ReturnCommand.php
+++ b/src/SmsCommand/ReturnCommand.php
@@ -23,7 +23,7 @@ class ReturnCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->returnBike($user->getUserId(), $bikeNumber, $standName, $note);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/src/SmsCommand/RevertCommand.php
+++ b/src/SmsCommand/RevertCommand.php
@@ -24,7 +24,7 @@ class RevertCommand extends AbstractCommand implements SmsCommandInterface
     {
         $response = $this->rentSystem->revertBike($user->getUserId(), $bikeNumber);
 
-        return $response['message'];
+        return $response->getMessage();
     }
 
     public function getHelpMessage(): string

--- a/tests/Application/Controller/Api/Bike/BikeForceRentReturnTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeForceRentReturnTest.php
@@ -60,7 +60,7 @@ class BikeForceRentReturnTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');
         $this->assertArrayHasKey('newCode', $response['params'], 'Response params does not contain newCode');
@@ -140,7 +140,7 @@ class BikeForceRentReturnTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
         $this->assertSame($response['code'], 'bike.return.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('standName', $response['params'], 'Response params does not contain standName');

--- a/tests/Application/Controller/Api/Bike/BikeLastUsageTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeLastUsageTest.php
@@ -22,7 +22,9 @@ class BikeLastUsageTest extends BikeSharingWebTestCase
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($user);
 
-        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
+        $rentSystemFactory = $this->client->getContainer()
+            ->get(RentSystemFactory::class)
+            ->getRentSystem(RentSystemType::WEB);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME, '', true);
         $rentSystemFactory->rentBike($user->getUserId(), self::BIKE_NUMBER);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME);

--- a/tests/Application/Controller/Api/Bike/BikeLastUsageTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeLastUsageTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Enum\Action;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ class BikeLastUsageTest extends BikeSharingWebTestCase
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($user);
 
-        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME, '', true);
         $rentSystemFactory->rentBike($user->getUserId(), self::BIKE_NUMBER);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME);

--- a/tests/Application/Controller/Api/Bike/BikeRentTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeRentTest.php
@@ -7,6 +7,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\UserRepository;
@@ -30,7 +31,7 @@ class BikeRentTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -44,7 +45,7 @@ class BikeRentTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -83,7 +84,7 @@ class BikeRentTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertSame($response['code'], 'bike.rent.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');

--- a/tests/Application/Controller/Api/Bike/BikeReturnTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeReturnTest.php
@@ -7,6 +7,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeReturnEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -31,7 +32,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -45,7 +46,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -70,7 +71,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
         $response = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
         $this->assertArrayHasKey('message', $response, 'Response does not contain message key');
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
 
         $this->client->getContainer()->get('event_dispatcher')->addListener(
             BikeReturnEvent::class,
@@ -95,7 +96,7 @@ class BikeReturnTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
         $this->assertSame($response['code'], 'bike.return.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('standName', $response['params'], 'Response params does not contain standName');

--- a/tests/Application/Controller/Api/Bike/BikeRevertTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeRevertTest.php
@@ -7,6 +7,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRevertEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -33,7 +34,7 @@ class BikeRevertTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -70,7 +71,7 @@ class BikeRevertTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertSame($response['code'], 'bike.rent.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');
@@ -98,7 +99,7 @@ class BikeRevertTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . $response['message']);
+        $this->assertFalse($response['error'], 'Response with error: ' . $response['message']);
         $this->assertSame($response['code'], 'bike.revert.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('standName', $response['params'], 'Response params does not contain standName');

--- a/tests/Application/Controller/Api/Bike/BikeTripTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeTripTest.php
@@ -22,7 +22,9 @@ class BikeTripTest extends BikeSharingWebTestCase
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($user);
 
-        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
+        $rentSystemFactory = $this->client->getContainer()
+            ->get(RentSystemFactory::class)
+            ->getRentSystem(RentSystemType::WEB);
         $rentSystemFactory->rentBike($user->getUserId(), self::BIKE_NUMBER, true);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME);
 

--- a/tests/Application/Controller/Api/Bike/BikeTripTest.php
+++ b/tests/Application/Controller/Api/Bike/BikeTripTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\Api\Bike;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ class BikeTripTest extends BikeSharingWebTestCase
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($user);
 
-        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystemFactory = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $rentSystemFactory->rentBike($user->getUserId(), self::BIKE_NUMBER, true);
         $rentSystemFactory->returnBike($user->getUserId(), self::BIKE_NUMBER, self::STAND_NAME);
 

--- a/tests/Application/Controller/Api/Report/InactiveBikesReportTest.php
+++ b/tests/Application/Controller/Api/Report/InactiveBikesReportTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\Api\Report;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
@@ -109,7 +110,7 @@ class InactiveBikesReportTest extends BikeSharingWebTestCase
 
     private function simulateBikeActivity(int $bikeNumber, string $standName, string $lastReturnTime): void
     {
-        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $returnTime = new \DateTimeImmutable($lastReturnTime);
 
         static::mockTime($returnTime->sub(new \DateInterval('PT2M'))->format('Y-m-d H:i:s'));
@@ -137,7 +138,7 @@ class InactiveBikesReportTest extends BikeSharingWebTestCase
     {
         static::mockTime('2000-01-01 00:00:00');
 
-        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         foreach ([self::BIKE_INACTIVE_SHORT, self::BIKE_INACTIVE_LONG, self::BIKE_ON_SERVICE_STAND] as $bikeNumber) {
             $rentSystem->returnBike($this->adminUserId, $bikeNumber, self::SERVICE_STAND_NAME, '', true);
         }

--- a/tests/Application/Controller/Api/Stand/StandBikeListTest.php
+++ b/tests/Application/Controller/Api/Stand/StandBikeListTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\Api\Stand;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Rent\RentSystemFactory;
@@ -41,7 +42,7 @@ class StandBikeListTest extends BikeSharingWebTestCase
         #add bike to stand with note
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/Api/User/UserBikeTest.php
+++ b/tests/Application/Controller/Api/User/UserBikeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Application\Controller\Api\User;
 
 use BikeShare\App\Security\UserProvider;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
@@ -27,7 +28,7 @@ class UserBikeTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -41,7 +42,7 @@ class UserBikeTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -72,7 +73,7 @@ class UserBikeTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('error', $response, 'Response does not contain error key');
         $this->assertArrayHasKey('code', $response, 'Response does not contain code');
         $this->assertArrayHasKey('params', $response, 'Response does not contain params');
-        $this->assertSame(0, $response['error'], 'Response with error: ' . json_encode($response));
+        $this->assertFalse($response['error'], 'Response with error: ' . json_encode($response));
         $this->assertSame($response['code'], 'bike.rent.success', 'Invalid response code');
         $this->assertArrayHasKey('bikeNumber', $response['params'], 'Response params does not contain bikeNumber');
         $this->assertArrayHasKey('currentCode', $response['params'], 'Response params does not contain currentCode');

--- a/tests/Application/Controller/ScanControllerTest.php
+++ b/tests/Application/Controller/ScanControllerTest.php
@@ -8,6 +8,7 @@ use BikeShare\App\Security\UserProvider;
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
 use BikeShare\Event\BikeReturnEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -32,7 +33,7 @@ class ScanControllerTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -46,7 +47,7 @@ class ScanControllerTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/RentCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/RentCommandTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRentEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\UserRepository;
@@ -30,7 +31,7 @@ class RentCommandTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -44,7 +45,7 @@ class RentCommandTest extends BikeSharingWebTestCase
     {
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/ReturnCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/ReturnCommandTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeReturnEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -33,7 +34,7 @@ class ReturnCommandTest extends BikeSharingWebTestCase
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
         #force return bike by admin
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -45,7 +46,7 @@ class ReturnCommandTest extends BikeSharingWebTestCase
         #rent bike by user
         $user = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->rentBike(
                 $user['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/RevertCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/RevertCommandTest.php
@@ -6,6 +6,7 @@ namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Event\BikeRevertEvent;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
@@ -32,7 +33,7 @@ class RevertCommandTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('sms')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::SMS)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Application/Controller/SmsRequestController/WhereCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/WhereCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller\SmsRequestController;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
@@ -24,7 +25,7 @@ class WhereCommandTest extends BikeSharingWebTestCase
         $admin = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        $this->client->getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,

--- a/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
+++ b/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Integration\Command;
 
 use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -94,7 +95,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
 
     private function simulateBikeActivity(int $bikeNumber, string $standName, string $lastReturnTime): void
     {
-        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         $returnTime = new \DateTimeImmutable($lastReturnTime);
 
         static::mockTime($returnTime->sub(new \DateInterval('PT2M'))->format('Y-m-d H:i:s'));
@@ -111,7 +112,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
     {
         static::mockTime('2000-01-01 00:00:00');
 
-        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
         foreach ([self::BIKE_INACTIVE_SHORT, self::BIKE_INACTIVE_LONG, self::BIKE_ON_SERVICE_STAND] as $bikeNumber) {
             $rentSystem->returnBike($this->adminUserId, $bikeNumber, self::SERVICE_STAND_NAME, '', true);
         }

--- a/tests/Integration/Command/LongRentalCheckCommandTest.php
+++ b/tests/Integration/Command/LongRentalCheckCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Integration\Command;
 
 use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemFactory;
 use BikeShare\Repository\UserRepository;
 use BikeShare\SmsConnector\SmsConnectorInterface;
@@ -35,7 +36,7 @@ class LongRentalCheckCommandTest extends BikeSharingKernelTestCase
         $admin = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
 
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -49,7 +50,7 @@ class LongRentalCheckCommandTest extends BikeSharingKernelTestCase
     {
         $admin = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike(
                 $admin['userId'],
                 self::BIKE_NUMBER,
@@ -71,7 +72,7 @@ class LongRentalCheckCommandTest extends BikeSharingKernelTestCase
 
         $user = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->rentBike($user['userId'], self::BIKE_NUMBER);
 
         static::mockTime('+' . $_ENV['WATCHES_LONG_RENTAL'] . ' hours 15 minutes');

--- a/tests/Integration/EventListener/LongStandBonusEventListenerFunctionalTest.php
+++ b/tests/Integration/EventListener/LongStandBonusEventListenerFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Integration\EventListener;
 
+use BikeShare\Rent\Enum\RentSystemType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Db\DbInterface;
@@ -46,7 +47,7 @@ class LongStandBonusEventListenerFunctionalTest extends BikeSharingKernelTestCas
 
         $admin = self::getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
-        self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web')
+        self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB)
             ->returnBike($admin['userId'], self::BIKE_NUMBER, self::STAND1_NAME, '', true);
 
         $_ENV = $this->originalEnv;
@@ -70,7 +71,7 @@ class LongStandBonusEventListenerFunctionalTest extends BikeSharingKernelTestCas
         $userRepository = self::getContainer()->get(UserRepository::class);
         $standRepository = self::getContainer()->get(StandRepository::class);
         $creditSystem = self::getContainer()->get(CreditSystemInterface::class);
-        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem('web');
+        $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
 
         $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
         $admin = $userRepository->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);

--- a/tests/Unit/SmsCommand/ForceRentCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceRentCommandTest.php
@@ -44,7 +44,7 @@ class ForceRentCommandTest extends TestCase
             ->expects($this->once())
             ->method('rentBike')
             ->with($userId, $bikeNumber, true)
-            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', [], RentSystemType::SMS));
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', RentSystemType::SMS, []));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/ForceRentCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceRentCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\ForceRentCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +44,7 @@ class ForceRentCommandTest extends TestCase
             ->expects($this->once())
             ->method('rentBike')
             ->with($userId, $bikeNumber, true)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/ForceReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceReturnCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\ForceReturnCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,7 +46,7 @@ class ForceReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, $note, true)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName, $note));
     }
@@ -62,8 +64,8 @@ class ForceReturnCommandTest extends TestCase
         $this->rentSystemMock
             ->expects($this->once())
             ->method('returnBike')
-            ->with($userId, $bikeNumber, $standName, '', true)
-            ->willReturn(['message' => $expectedMessage]);
+            ->with($userId, $bikeNumber, $standName, null, true)
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName));
     }

--- a/tests/Unit/SmsCommand/ForceReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ForceReturnCommandTest.php
@@ -46,7 +46,7 @@ class ForceReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, $note, true)
-            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', RentSystemType::SMS, []));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName, $note));
     }
@@ -65,7 +65,7 @@ class ForceReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, null, true)
-            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', RentSystemType::SMS, []));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName));
     }

--- a/tests/Unit/SmsCommand/RentCommandTest.php
+++ b/tests/Unit/SmsCommand/RentCommandTest.php
@@ -44,7 +44,7 @@ class RentCommandTest extends TestCase
             ->expects($this->once())
             ->method('rentBike')
             ->with($userId, $bikeNumber)
-            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', [], RentSystemType::SMS));
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', RentSystemType::SMS, []));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/RentCommandTest.php
+++ b/tests/Unit/SmsCommand/RentCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\RentCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +44,7 @@ class RentCommandTest extends TestCase
             ->expects($this->once())
             ->method('rentBike')
             ->with($userId, $bikeNumber)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.rent.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/ReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ReturnCommandTest.php
@@ -46,7 +46,7 @@ class ReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, $note)
-            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', RentSystemType::SMS, []));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName, $note));
     }

--- a/tests/Unit/SmsCommand/ReturnCommandTest.php
+++ b/tests/Unit/SmsCommand/ReturnCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\ReturnCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,7 +46,7 @@ class ReturnCommandTest extends TestCase
             ->expects($this->once())
             ->method('returnBike')
             ->with($userId, $bikeNumber, $standName, $note)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.return.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber, $standName, $note));
     }

--- a/tests/Unit/SmsCommand/RevertCommandTest.php
+++ b/tests/Unit/SmsCommand/RevertCommandTest.php
@@ -44,7 +44,7 @@ class RevertCommandTest extends TestCase
             ->expects($this->once())
             ->method('revertBike')
             ->with($userId, $bikeNumber)
-            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.revert.success', [], RentSystemType::SMS));
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.revert.success', RentSystemType::SMS, []));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }

--- a/tests/Unit/SmsCommand/RevertCommandTest.php
+++ b/tests/Unit/SmsCommand/RevertCommandTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\SmsCommand;
 
 use BikeShare\App\Entity\User;
+use BikeShare\Rent\DTO\RentSystemResult;
+use BikeShare\Rent\Enum\RentSystemType;
 use BikeShare\Rent\RentSystemInterface;
 use BikeShare\SmsCommand\RevertCommand;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +44,7 @@ class RevertCommandTest extends TestCase
             ->expects($this->once())
             ->method('revertBike')
             ->with($userId, $bikeNumber)
-            ->willReturn(['message' => $expectedMessage]);
+            ->willReturn(new RentSystemResult(false, $expectedMessage, 'bike.revert.success', [], RentSystemType::SMS));
 
         $this->assertSame($expectedMessage, ($this->command)($userMock, $bikeNumber));
     }


### PR DESCRIPTION
## Summary
- move `RentSystemResult` to `src/Rent/DTO`
- add `RentSystemType` enum and replace string system type usage across RentSystem
- update RentSystem factory/interface/contracts to use enum and DTO
- update controllers, DI config, and tests to use enum-based `getRentSystem(...)`

## Validation
- `php bin/console cache:clear` (APP_ENV=test)
- `php bin/console load:fixtures`
- `vendor/bin/phpunit --configuration phpunit.xml`

All tests passed: 299 tests, 2314 assertions.