### PR TITLE
fix(api): correct admin stands/bikes JSON response types

### DIFF
--- a/src/Controller/PersonalStatsController.php
+++ b/src/Controller/PersonalStatsController.php
@@ -31,7 +31,11 @@ class PersonalStatsController extends AbstractController
 
         $userId = $userRepository->findItemByPhoneNumber($this->getUser()->getUserIdentifier())['userId'];
         $stats = $statsRepository->getUserStatsForYear((int)$userId, (int)$year);
-        $stands = $standRepository->findAll();
+        $standsList = $standRepository->findAll();
+        $stands = [];
+        foreach ($standsList as $stand) {
+            $stands[$stand['standId']] = $stand;
+        }
 
         return $this->render('stats.html.twig', [
             'stats' => $stats,

--- a/src/Repository/BikeRepository.php
+++ b/src/Repository/BikeRepository.php
@@ -31,6 +31,7 @@ class BikeRepository
         )->fetchAllAssoc();
 
         foreach ($bikes as &$bike) {
+            $bike['isServiceStand'] = (bool) $bike['isServiceStand'];
             /**
              * Should be optimized to one query
              */
@@ -82,6 +83,12 @@ class BikeRepository
                 'bikeNumber' => $bikeNumber,
             ]
         )->fetchAssoc();
+
+        if (empty($bike)) {
+            return [];
+        }
+
+        $bike['isServiceStand'] = (bool) $bike['isServiceStand'];
 
         /**
          * Should be optimized to one query

--- a/src/Repository/StandRepository.php
+++ b/src/Repository/StandRepository.php
@@ -29,12 +29,7 @@ class StandRepository
                 ORDER BY standName'
         )->fetchAllAssoc();
 
-        $stands = [];
-        foreach ($result as $stand) {
-            $stands[$stand['standId']] = $stand;
-        }
-
-        return $stands;
+        return $result;
     }
 
     public function findAllExtended($city = null): array


### PR DESCRIPTION
## Problem

The admin API endpoints for stands and bikes returned JSON that couldn't be parsed by strictly-typed clients (e.g. Android app with Moshi):

1. **`GET /api/v1/admin/stands`** returned a JSON **object** keyed by `standId` (`{"1": {...}, "2": {...}}`) instead of an **array** (`[{...}, {...}]`), because `StandRepository::findAll()` built an associative array.

2. **`GET /api/v1/admin/bikes`** returned `isServiceStand` as `0`/`1` integers instead of `true`/`false` booleans, because MySQL `REGEXP` returns an integer.

## Solution

- `StandRepository::findAll()` now returns the query result directly (sequential array)
- `PersonalStatsController` builds the `standId`-keyed lookup map locally (only consumer that needs it)
- `BikeRepository` casts `isServiceStand` to `(bool)` in both `findAll()` and `findItem()`

## Testing

- Verified `QrCodeGeneratorController` and `PersonalStatsController` still work correctly
- Admin JS already handles both formats via `Array.isArray()` check