### PR TITLE
chore(logging): skip markers and me routes in request logs

### DIFF
--- a/src/EventListener/ControllerEventListener.php
+++ b/src/EventListener/ControllerEventListener.php
@@ -14,7 +14,6 @@ class ControllerEventListener
     private const LOGGED_ROUTES = [
         'api_v1_stands',
         'api_v1_stand_bikes',
-        'api_v1_stand_markers',
         'api_v1_admin_stand_item',
         'api_v1_admin_stand_notes_delete',
         'api_v1_admin_bikes',
@@ -39,8 +38,6 @@ class ControllerEventListener
         'api_v1_admin_bike_set_code',
         'api_v1_coupon_redeem',
         'api_v1_me_city',
-        'api_v1_me_bikes',
-        'api_v1_me_limits',
         'api_v1_bike_trip',
         // Scan routes used by the public flow.
         'scan_bike',


### PR DESCRIPTION
Summary:\n- stop logging request hits for /api/v1/stands/markers\n- stop logging request hits for /api/v1/me/bikes\n- stop logging request hits for /api/v1/me/limits\n- remove these route names from ControllerEventListener LOGGED_ROUTES\n\nValidation:\n- phpcs for src/EventListener/ControllerEventListener.php