### PR TITLE
feat(api): user phone-confirm, registration form validation, 403 for unconfirmed phone

### DIFF
--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -88,7 +88,7 @@ return function (SecurityConfig $security) {
 
     $security
         ->accessControl()
-        ->path('^/api/v1/auth/(token|refresh|logout)$')
+        ->path('^/api/v1/auth/(token|refresh|logout|register|cities)$')
         ->roles(['PUBLIC_ACCESS']);
     $security
         ->accessControl()

--- a/config/routes/api.php
+++ b/config/routes/api.php
@@ -12,7 +12,12 @@ return function (RoutingConfigurator $routes) {
     $routes->add('api_v1_auth_logout', '/api/v1/auth/logout')
         ->methods(['POST'])
         ->controller([\BikeShare\Controller\Api\V1\AuthController::class, 'logout']);
-
+    $routes->add('api_v1_auth_register', '/api/v1/auth/register')
+        ->methods(['POST'])
+        ->controller([\BikeShare\Controller\Api\V1\AuthController::class, 'register']);
+    $routes->add('api_v1_auth_cities', '/api/v1/auth/cities')
+        ->methods(['GET'])
+        ->controller([\BikeShare\Controller\Api\V1\AuthController::class, 'cities']);
     $routes->add('api_v1_stands', '/api/v1/admin/stands')
         ->methods(['GET'])
         ->controller([\BikeShare\Controller\Api\V1\Admin\StandsController::class, 'index']);
@@ -111,6 +116,12 @@ return function (RoutingConfigurator $routes) {
     $routes->add('api_v1_me_trips', '/api/v1/me/trips')
         ->methods(['GET'])
         ->controller([\BikeShare\Controller\Api\V1\UsersController::class, 'trips']);
+    $routes->add('api_v1_user_phone_confirm_request', '/api/v1/user/phone-confirm/request')
+        ->methods(['POST'])
+        ->controller([\BikeShare\Controller\Api\V1\UsersController::class, 'phoneConfirmRequest']);
+    $routes->add('api_v1_user_phone_confirm_verify', '/api/v1/user/phone-confirm/verify')
+        ->methods(['POST'])
+        ->controller([\BikeShare\Controller\Api\V1\UsersController::class, 'phoneConfirmVerify']);
 
     $routes->add('api_v1_admin_user_credit_add', '/api/v1/admin/users/{userId}/credit')
         ->methods(['PUT'])

--- a/src/Controller/Api/V1/AuthController.php
+++ b/src/Controller/Api/V1/AuthController.php
@@ -7,9 +7,14 @@ namespace BikeShare\Controller\Api\V1;
 use BikeShare\App\Security\JwtTokenService;
 use BikeShare\App\Security\UserConfirmedEmailChecker;
 use BikeShare\App\Security\UserProvider;
+use BikeShare\Form\RegistrationFormType;
+use BikeShare\Purifier\PhonePurifierInterface;
+use BikeShare\Repository\CityRepository;
 use BikeShare\Repository\RefreshTokenRepository;
 use BikeShare\Repository\UserRepository;
+use BikeShare\User\UserRegistration;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -26,7 +31,65 @@ class AuthController extends AbstractController
         private readonly JwtTokenService $jwtTokenService,
         private readonly RefreshTokenRepository $refreshTokenRepository,
         private readonly UserConfirmedEmailChecker $userConfirmedEmailChecker,
+        private readonly CityRepository $cityRepository,
+        private readonly UserRegistration $userRegistration,
+        private readonly PhonePurifierInterface $phonePurifier,
+        private readonly bool $isSmsSystemEnabled = false,
     ) {
+    }
+
+    public function cities(): Response
+    {
+        $cities = array_keys($this->cityRepository->findAvailableCities());
+
+        return $this->json($cities);
+    }
+
+    public function register(Request $request): Response
+    {
+        $payload = $request->getPayload()->all();
+        $form = $this->createForm(RegistrationFormType::class);
+        $form->submit($payload);
+
+        if (!$form->isValid()) {
+            $detail = $this->getFirstFormErrorMessage($form->getErrors(true));
+
+            return $this->json(
+                ['detail' => $detail],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
+        $data = $form->getData();
+        $purifiedNumber = $this->phonePurifier->purify($data['number']);
+
+        $this->userRegistration->register(
+            $purifiedNumber,
+            $data['useremail'],
+            $data['password'],
+            $data['city'],
+            $data['fullname'],
+            0
+        );
+
+        return $this->json(
+            [
+                'message' => 'You have been successfully registered. Please, check your email '
+                    . 'and read the instructions to finish your registration.',
+            ],
+            Response::HTTP_CREATED
+        );
+    }
+
+    private function getFirstFormErrorMessage(FormErrorIterator $errors): string
+    {
+        foreach ($errors as $error) {
+            if ($error->getMessage() !== '') {
+                return $error->getMessage();
+            }
+        }
+
+        return 'Validation failed.';
     }
 
     public function token(Request $request): Response
@@ -67,6 +130,8 @@ class AuthController extends AbstractController
             $request->getClientIp()
         );
 
+        $phoneConfirmed = !$this->isSmsSystemEnabled || $user->isNumberConfirmed();
+
         return $this->json([
             'accessToken' => $accessToken['token'],
             'accessTokenExpiresAt' => $accessToken['expiresAt']->format(\DateTimeInterface::ATOM),
@@ -75,6 +140,7 @@ class AuthController extends AbstractController
             'refreshTokenExpiresAt' => $refreshToken['expiresAt']->format(\DateTimeInterface::ATOM),
             'refreshTokenExpiresIn' => $refreshToken['expiresIn'],
             'tokenType' => 'Bearer',
+            'phoneConfirmed' => $phoneConfirmed,
         ]);
     }
 
@@ -138,6 +204,8 @@ class AuthController extends AbstractController
             $request->getClientIp(),
         );
 
+        $phoneConfirmed = !$this->isSmsSystemEnabled || $user->isNumberConfirmed();
+
         return $this->json([
             'accessToken' => $accessToken['token'],
             'accessTokenExpiresAt' => $accessToken['expiresAt']->format(\DateTimeInterface::ATOM),
@@ -146,6 +214,7 @@ class AuthController extends AbstractController
             'refreshTokenExpiresAt' => $newRefreshToken['expiresAt']->format(\DateTimeInterface::ATOM),
             'refreshTokenExpiresIn' => $newRefreshToken['expiresIn'],
             'tokenType' => 'Bearer',
+            'phoneConfirmed' => $phoneConfirmed,
         ]);
     }
 

--- a/src/Controller/Api/V1/UsersController.php
+++ b/src/Controller/Api/V1/UsersController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace BikeShare\Controller\Api\V1;
 
 use BikeShare\Credit\CreditSystemInterface;
+use BikeShare\Enum\Action;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\CityRepository;
 use BikeShare\Repository\HistoryRepository;
 use BikeShare\Repository\UserRepository;
+use BikeShare\Sms\SmsSenderInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,12 +18,15 @@ use Symfony\Component\HttpFoundation\Response;
 class UsersController extends AbstractController
 {
     public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly HistoryRepository $historyRepository,
+        private readonly SmsSenderInterface $smsSender,
         private readonly int $freeTimeMinutes = 30,
+        private readonly bool $isSmsSystemEnabled = false,
     ) {
     }
 
     public function changeCity(
-        UserRepository $userRepository,
         CityRepository $cityRepository,
         Request $request
     ): Response {
@@ -40,7 +45,7 @@ class UsersController extends AbstractController
             );
         }
 
-        $userRepository->updateUserCity($userId, $city);
+        $this->userRepository->updateUserCity($userId, $city);
 
         return $this->json(
             [
@@ -62,12 +67,11 @@ class UsersController extends AbstractController
 
     public function userLimit(
         BikeRepository $bikeRepository,
-        UserRepository $userRepository,
         CreditSystemInterface $creditSystem
     ): Response {
         $userId = $this->getUser()->getUserId();
         $userBikes = $bikeRepository->findRentedBikesByUserId($userId);
-        $userInfo = $userRepository->findItem($userId);
+        $userInfo = $this->userRepository->findItem($userId);
         $userCredit = $creditSystem->getUserCredit($userId);
 
         $result = [
@@ -75,6 +79,7 @@ class UsersController extends AbstractController
             'rented' => count($userBikes),
             'userCredit' => $userCredit,
             'freeTimeMinutes' => $this->freeTimeMinutes,
+            'privileges' => (int)($userInfo['privileges'] ?? 0),
         ];
 
         return $this->json($result);
@@ -96,11 +101,74 @@ class UsersController extends AbstractController
         return $this->json($data);
     }
 
-    public function trips(HistoryRepository $historyRepository): Response
+    public function trips(): Response
     {
         $userId = $this->getUser()->getUserId();
-        $trips = $historyRepository->findUserTripHistory($userId, 10);
+        $trips = $this->historyRepository->findUserTripHistory($userId, 10);
 
         return $this->json($trips);
+    }
+
+    public function phoneConfirmRequest(): Response
+    {
+        if (!$this->isSmsSystemEnabled) {
+            return $this->json(
+                ['detail' => 'Phone verification is not available.'],
+                Response::HTTP_SERVICE_UNAVAILABLE
+            );
+        }
+
+        $user = $this->getUser();
+        if ($user->isNumberConfirmed()) {
+            return $this->json(['message' => 'Phone number is already confirmed.']);
+        }
+
+        $number = $user->getNumber();
+        $smsCode = chr(rand(65, 90)) . chr(rand(65, 90)) . ' ' . rand(100000, 999999);
+        $sanitizedSmsCode = str_replace(' ', '', $smsCode);
+        $checkCode = md5('WB' . $number . $sanitizedSmsCode);
+
+        $text = 'Enter this code to verify your phone: ' . $smsCode;
+        $this->smsSender->send($number, $text);
+        $this->historyRepository->addItem(
+            $user->getUserId(),
+            0,
+            Action::PHONE_CONFIRM_REQUEST,
+            sprintf('%s;%s;%s', $number, $sanitizedSmsCode, $checkCode)
+        );
+
+        return $this->json(['checkCode' => $checkCode]);
+    }
+
+    public function phoneConfirmVerify(Request $request): Response
+    {
+        $user = $this->getUser();
+        if ($user->isNumberConfirmed()) {
+            return $this->json(['message' => 'Phone number is already confirmed.']);
+        }
+
+        $payload = $request->getPayload()->all();
+        $code = isset($payload['code']) ? str_replace(' ', '', trim((string)$payload['code'])) : '';
+        $checkCode = isset($payload['checkCode']) ? trim((string)$payload['checkCode']) : '';
+
+        if ($code === '' || $checkCode === '') {
+            return $this->json(
+                ['detail' => 'code and checkCode are required'],
+                Response::HTTP_BAD_REQUEST
+            );
+        }
+
+        $number = $user->getNumber();
+        $parameter = $number . ';' . $code . ';' . $checkCode;
+        $history = $this->historyRepository->findConfirmationRequest($parameter, $user->getUserId());
+
+        if ($history === null) {
+            return $this->json(['detail' => 'Invalid confirmation code.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $this->userRepository->confirmUserNumber($user->getUserId());
+        $this->historyRepository->addItem($user->getUserId(), 0, Action::PHONE_CONFIRMED, '');
+
+        return $this->json(['message' => 'Phone number confirmed successfully.']);
     }
 }

--- a/src/EventListener/PhoneConfirmedEventListener.php
+++ b/src/EventListener/PhoneConfirmedEventListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\EventListener;
 
 use BikeShare\App\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -13,6 +14,8 @@ use Symfony\Bundle\SecurityBundle\Security;
 class PhoneConfirmedEventListener
 {
     private const ALLOWED_ROUTES = [
+        'api_v1_user_phone_confirm_request',
+        'api_v1_user_phone_confirm_verify',
         'sms_request',
         'sms_request_old',
         'user_confirm_email',
@@ -52,11 +55,24 @@ class PhoneConfirmedEventListener
             return;
         }
 
-        if (in_array($event->getRequest()->attributes->get('_route'), self::ALLOWED_ROUTES)) {
+        if ($user->isNumberConfirmed()) {
             return;
         }
 
-        if (!$user->isNumberConfirmed()) {
+        $request = $event->getRequest();
+        $path = $request->getPathInfo();
+        $route = $request->attributes->get('_route');
+
+        if (in_array($route, self::ALLOWED_ROUTES, true)) {
+            return;
+        }
+
+        if (str_starts_with($path, '/api/v1')) {
+            $event->setResponse(new JsonResponse(
+                ['detail' => 'Phone number must be confirmed.'],
+                JsonResponse::HTTP_FORBIDDEN
+            ));
+        } else {
             $redirectUrl = $this->urlGenerator->generate('user_confirm_phone');
             $event->setResponse(new RedirectResponse($redirectUrl));
         }

--- a/tests/Application/Controller/Api/Auth/AuthFlowTest.php
+++ b/tests/Application/Controller/Api/Auth/AuthFlowTest.php
@@ -29,6 +29,8 @@ class AuthFlowTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('accessToken', $tokenPayload);
         $this->assertArrayHasKey('refreshToken', $tokenPayload);
         $this->assertArrayHasKey('tokenType', $tokenPayload);
+        $this->assertArrayHasKey('phoneConfirmed', $tokenPayload);
+        $this->assertIsBool($tokenPayload['phoneConfirmed']);
         $this->assertSame('Bearer', $tokenPayload['tokenType']);
         $this->assertSame('v1', $this->getTokenHeaderField($tokenPayload['accessToken'], 'kid'));
 
@@ -53,6 +55,8 @@ class AuthFlowTest extends BikeSharingWebTestCase
 
         $this->assertArrayHasKey('accessToken', $refreshedPayload);
         $this->assertArrayHasKey('refreshToken', $refreshedPayload);
+        $this->assertArrayHasKey('phoneConfirmed', $refreshedPayload);
+        $this->assertIsBool($refreshedPayload['phoneConfirmed']);
         $this->assertNotSame($tokenPayload['accessToken'], $refreshedPayload['accessToken']);
         $this->assertNotSame($tokenPayload['refreshToken'], $refreshedPayload['refreshToken']);
     }

--- a/tests/Application/Controller/Api/Auth/PhoneConfirmApiTest.php
+++ b/tests/Application/Controller/Api/Auth/PhoneConfirmApiTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * Application tests for phone confirmation API endpoints.
+ * Full flow test registers a user, confirms email, then confirms phone via API.
+ */
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Controller\Api\Auth;
+
+use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Purifier\PhonePurifierInterface;
+use BikeShare\Repository\RegistrationRepository;
+use BikeShare\Repository\UserRepository;
+use BikeShare\SmsConnector\SmsConnectorInterface;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class PhoneConfirmApiTest extends BikeSharingWebTestCase
+{
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalEnv = $_ENV;
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV = $this->originalEnv;
+        parent::tearDown();
+    }
+
+    public function testPhoneConfirmRequestRequiresAuthentication(): void
+    {
+        $this->client->request(Request::METHOD_POST, '/api/v1/user/phone-confirm/request');
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testPhoneConfirmVerifyRequiresAuthentication(): void
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/verify',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode(['code' => 'AB123456', 'checkCode' => 'some-check-code'])
+        );
+        $this->assertResponseStatusCodeSame(401);
+    }
+
+    public function testFullRegistrationAndPhoneConfirmFlow(): void
+    {
+        $userEmail = 'test_' . time() . '_' . bin2hex(random_bytes(4)) . '@example.com';
+        $userPhone = '+421901' . rand(100000, 999999);
+        $password = 'password123';
+        $city = 'Default City';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/auth/register',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'fullname' => 'John Doe',
+                'city' => $city,
+                'useremail' => $userEmail,
+                'password' => $password,
+                'password2' => $password,
+                'number' => $userPhone,
+                'agree' => true,
+            ])
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        $mailSender = $this->client->getContainer()->get(MailSenderInterface::class);
+        $sendEmails = $mailSender->getSentMessages();
+        $this->assertCount(1, $sendEmails);
+        $body = $sendEmails[0]['message'] ?? '';
+        $this->assertNotNull($body);
+        preg_match('/(\/user\/confirm\/email\/[a-z0-9]+)/', $body, $matches);
+        $this->assertNotEmpty($matches[1], 'Email confirmation link not found');
+        $confirmationLink = $matches[1];
+
+        $this->client->request(Request::METHOD_GET, $confirmationLink);
+        $this->assertResponseRedirects();
+
+        $userRepository = $this->client->getContainer()->get(UserRepository::class);
+        $registrationRepository = $this->client->getContainer()->get(RegistrationRepository::class);
+        $user = $userRepository->findItemByEmail($userEmail);
+        $this->assertNotNull($user);
+        $this->assertNull($registrationRepository->findItemByUserId($user['userId']));
+
+        $phonePurifier = $this->client->getContainer()->get(PhonePurifierInterface::class);
+        $purifiedPhone = $phonePurifier->purify($userPhone);
+
+        $tokenPayload = $this->obtainToken($purifiedPhone, $password);
+        $this->assertArrayHasKey('accessToken', $tokenPayload);
+        $this->assertFalse($tokenPayload['phoneConfirmed'], 'New user should have phone not confirmed');
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/request',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer ' . $tokenPayload['accessToken']]
+        );
+        $this->assertResponseIsSuccessful();
+        $requestData = $this->decodeApiResponseData();
+        $this->assertArrayHasKey('checkCode', $requestData);
+        $checkCode = $requestData['checkCode'];
+
+        $smsConnector = $this->client->getContainer()->get(SmsConnectorInterface::class);
+        $this->assertCount(1, $smsConnector->getSentMessages());
+        $sent = $smsConnector->getSentMessages()[0];
+        $this->assertSame($purifiedPhone, $sent['number']);
+        preg_match('/Enter this code to verify your phone: ([A-Z]{2} \d+)/', $sent['text'], $smsMatches);
+        $this->assertNotEmpty($smsMatches[1] ?? null);
+        $smsCode = str_replace(' ', '', $smsMatches[1]);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/verify',
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer ' . $tokenPayload['accessToken'],
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode(['code' => $smsCode, 'checkCode' => $checkCode])
+        );
+        $this->assertResponseIsSuccessful();
+        $verifyData = $this->decodeApiResponseData();
+        $this->assertArrayHasKey('message', $verifyData);
+        $this->assertStringContainsString('confirmed', $verifyData['message']);
+
+        $user = $userRepository->findItemByEmail($userEmail);
+        $this->assertSame(1, (int)$user['isNumberConfirmed']);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/request',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer ' . $tokenPayload['accessToken']]
+        );
+        $this->assertResponseIsSuccessful();
+        $data = $this->decodeApiResponseData();
+        $this->assertArrayHasKey('message', $data);
+        $this->assertStringContainsString('already confirmed', $data['message']);
+    }
+
+    public function testPhoneConfirmVerifyRejectsInvalidCode(): void
+    {
+        $userEmail = 'test_invalid_' . time() . '_' . bin2hex(random_bytes(4)) . '@example.com';
+        $userPhone = '+421902' . rand(100000, 999999);
+        $password = 'password123';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/auth/register',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'fullname' => 'Jane Doe',
+                'city' => 'Default City',
+                'useremail' => $userEmail,
+                'password' => $password,
+                'password2' => $password,
+                'number' => $userPhone,
+                'agree' => true,
+            ])
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        $mailSender = $this->client->getContainer()->get(MailSenderInterface::class);
+        preg_match('/(\/user\/confirm\/email\/[a-z0-9]+)/', $mailSender->getSentMessages()[0]['message'], $m);
+        $this->client->request(Request::METHOD_GET, $m[1]);
+
+        $phonePurifier = $this->client->getContainer()->get(PhonePurifierInterface::class);
+        $tokenPayload = $this->obtainToken($phonePurifier->purify($userPhone), $password);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/request',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer ' . $tokenPayload['accessToken']]
+        );
+        $this->assertResponseIsSuccessful();
+        $requestData = $this->decodeApiResponseData();
+        $checkCode = $requestData['checkCode'];
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/verify',
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer ' . $tokenPayload['accessToken'],
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            json_encode(['code' => 'WRONG00', 'checkCode' => $checkCode])
+        );
+        $this->assertResponseStatusCodeSame(400);
+        $payload = $this->decodeJsonResponse();
+        $this->assertArrayHasKey('detail', $payload);
+        $this->assertStringContainsString('Invalid', $payload['detail']);
+    }
+
+    private function obtainToken(string $number, string $password): array
+    {
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/auth/token',
+            ['number' => $number, 'password' => $password]
+        );
+        $this->assertResponseIsSuccessful();
+
+        return $this->decodeApiResponseData();
+    }
+}

--- a/tests/Application/Controller/LoginControllerTest.php
+++ b/tests/Application/Controller/LoginControllerTest.php
@@ -14,7 +14,7 @@ class LoginControllerTest extends BikeSharingWebTestCase
     private const USER_PHONE_NUMBER = '421951555555';
     private const USER_PHONE_PASSWORD = 'password';
 
-    protected function setup(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);

--- a/tests/Application/Controller/UserControllerTest.php
+++ b/tests/Application/Controller/UserControllerTest.php
@@ -4,10 +4,28 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Controller;
 
+use BikeShare\Db\DbInterface;
+use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
 
 class UserControllerTest extends BikeSharingWebTestCase
 {
+    private const USER_PHONE = '421951555555';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $userRepository = $this->client->getContainer()->get(UserRepository::class);
+        $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE);
+        if ($user !== null) {
+            $db = $this->client->getContainer()->get(DbInterface::class);
+            $db->query(
+                'UPDATE users SET isNumberConfirmed = 1 WHERE userId = :userId',
+                ['userId' => $user['userId']]
+            );
+        }
+    }
+
     private function logIn(string $username, string $password)
     {
         $this->client->request('GET', '/login');
@@ -26,7 +44,7 @@ class UserControllerTest extends BikeSharingWebTestCase
 
     public function testUserProfilePage(): void
     {
-        $this->logIn('421951555555', 'password');
+        $this->logIn(self::USER_PHONE, 'password');
         $this->client->request('GET', '/user/profile');
         $this->assertResponseIsSuccessful();
         $this->assertSelectorTextContains('h1', 'User Profile');
@@ -34,7 +52,7 @@ class UserControllerTest extends BikeSharingWebTestCase
 
     public function testChangePassword(): void
     {
-        $this->logIn('421951555555', 'password');
+        $this->logIn(self::USER_PHONE, 'password');
         $crawler = $this->client->request('GET', '/user/profile');
 
         $form = $crawler->selectButton('Change Password')->form([
@@ -51,7 +69,7 @@ class UserControllerTest extends BikeSharingWebTestCase
         // Logout and login with new password
         $this->client->request('GET', '/logout');
         $this->client->followRedirect();
-        $this->logIn('421951555555', 'new-password');
+        $this->logIn(self::USER_PHONE, 'new-password');
         $this->assertResponseIsSuccessful();
     }
 }

--- a/tests/Integration/Security/RoutesAccessTest.php
+++ b/tests/Integration/Security/RoutesAccessTest.php
@@ -29,6 +29,8 @@ class RoutesAccessTest extends BikeSharingKernelTestCase
         '/api/v1/auth/token' => [Request::METHOD_POST],
         '/api/v1/auth/refresh' => [Request::METHOD_POST],
         '/api/v1/auth/logout' => [Request::METHOD_POST],
+        '/api/v1/auth/register' => [Request::METHOD_POST],
+        '/api/v1/auth/cities' => [Request::METHOD_GET],
         '/login' => [],
         '/sms/receive.php' => [],
         '/receive.php' => [],


### PR DESCRIPTION
## Changes
- **Phone-confirm API** moved from `/api/v1/auth/phone-confirm` to `/api/v1/user/phone-confirm` (UsersController)
- **PhoneConfirmedEventListener**: returns 403 for API when phone not confirmed, except phone-confirm routes; web redirect unchanged
- **AuthController::register** uses `RegistrationFormType` for validation
- **Tests**: PhoneConfirmApiTest full registration + phone confirm; LoginControllerTest setUp fix; UserControllerTest setIsNumberConfirmed in setUp