### PR TITLE
chore: make docker-compose ports configurable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,3 +8,10 @@ How to start web over docker
 2. optional - if you want https. Generate keys to docker-data/nginx/ssl/bikesharing.loc.crt and bikesharing.loc.key. Uncomment lines in docker-data/nginx/nginx.conf and docker-compose.yml
 3. run `docker compose up -d`
 4. go to `http://localhost:8100`, phpmyadmin is on url `http://localhost:81`, mysql server `db`, mysql user `root`, mysql password `password`, mysql database `bikesharing`
+
+To avoid port conflicts with other services, you can override host ports via environment variables:
+```bash
+DB_PORT=3308 WEB_PORT=8200 docker compose up -d
+```
+
+Available port variables: `NGINX_PORT` (default 80), `DB_PORT` (default 3306), `WEB_PORT` (default 8100), `PMA_PORT` (default 81).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,11 @@ cp .env.dist .env.dev
 docker compose up -d
 ```
 
+To avoid port conflicts, you can override host ports via environment variables:
+```bash
+DB_PORT=3308 WEB_PORT=8200 docker compose up -d
+```
+
 4. Install PHP dependencies:
 ```bash
 docker compose exec web composer install
@@ -38,12 +43,12 @@ The application will be available at:
 
 Services overview
 ----------
-| Service | Port | Description |
-|---------|------|-------------|
-| Nginx | 80 | Reverse proxy |
-| PHP 8.4 (Apache) | 8100 | Application server |
-| MariaDB 10.3 | 3306 | Database |
-| PHPMyAdmin | 81 | Database admin UI |
+| Service | Default port | Env variable | Description |
+|---------|-------------|--------------|-------------|
+| Nginx | 80 | `NGINX_PORT` | Reverse proxy |
+| PHP 8.4 (Apache) | 8100 | `WEB_PORT` | Application server |
+| MariaDB 10.3 | 3306 | `DB_PORT` | Database |
+| PHPMyAdmin | 81 | `PMA_PORT` | Database admin UI |
 
 Configuration (.env)
 ----------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,14 +9,14 @@ services:
       #- ./docker-data/nginx/ssl/bikesharing.loc.crt:/etc/nginx/certs/bikesharing.loc.crt
       #- ./docker-data/nginx/ssl/bikesharing.loc.key:/etc/nginx/certs/bikesharing.loc.key
     ports:
-      - 80:80
+      - ${NGINX_PORT:-80}:80
       #- 443:443
     links:
       - web
   db:
     image: mariadb:10.3
     ports:
-      - 3306:3306
+      - ${DB_PORT:-3306}:3306
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: bikesharing
@@ -29,7 +29,7 @@ services:
   web:
     build: .
     ports:
-      - "8100:80"
+      - "${WEB_PORT:-8100}:80"
     volumes:
       - ./:/var/www/html/
       - ./docker-data/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
@@ -43,7 +43,7 @@ services:
     links:
       - db
     ports:
-      - 81:80
+      - ${PMA_PORT:-81}:80
     environment:
       - PMA_HOST=db
       - PMA_USER=root


### PR DESCRIPTION
## Summary
- Allow overriding host ports via environment variables: `DB_PORT`, `WEB_PORT`, `NGINX_PORT`, `PMA_PORT`
- Default values match previous hardcoded ports, so no breaking change

## Usage
```bash
# Use custom ports to avoid conflicts
DB_PORT=3308 WEB_PORT=8200 docker compose up -d
```

## Test plan
- [ ] `docker compose up -d` works with default ports (no env vars set)
- [ ] `DB_PORT=3308 docker compose up -d` correctly binds DB to port 3308