### PR TITLE
fix: stop forwarding PhpMailer SMTP handshake to logger (stops credential leak)

### DIFF
--- a/src/Mail/PHPMailerMailSender.php
+++ b/src/Mail/PHPMailerMailSender.php
@@ -9,8 +9,6 @@ use Psr\Log\LoggerInterface;
 
 class PHPMailerMailSender implements MailSenderInterface
 {
-    private array $sendLog = [];
-
     public function __construct(
         private readonly string $fromEmail,
         private readonly string $fromName,
@@ -26,10 +24,7 @@ class PHPMailerMailSender implements MailSenderInterface
         $this->mailer->clearAllRecipients();
 
         $this->mailer->isSMTP(); // Set mailer to use SMTP
-        $this->mailer->SMTPDebug  = $this->debugLevel;
-        if ($this->debugLevel > 0 && $this->logger) {
-            $this->mailer->Debugoutput = $this->debugOutput(...);
-        }
+        $this->mailer->SMTPDebug = $this->debugLevel;
 
         $this->mailer->Host = $this->emailConfig["smtp_host"]; // Specify main and backup SMTP servers
         $this->mailer->Port = $this->emailConfig["smtp_port"]; // TCP port to connect to
@@ -44,23 +39,11 @@ class PHPMailerMailSender implements MailSenderInterface
         $this->mailer->Subject = $subject;
         $this->mailer->Body = $message;
 
-        $this->sendLog = [];
         $this->mailer->send();
-        if ($this->debugLevel > 0 && $this->logger && $this->sendLog !== []) {
-            $this->saveSendLog();
-        }
-    }
 
-    /**
-     * @internal
-     */
-    public function debugOutput($str, $level): void
-    {
-        $this->sendLog[] = sprintf('[%s] %s', $level, $str);
-    }
-
-    private function saveSendLog(): void
-    {
-        $this->logger->notice('PhpMailer Debug', ['sendLog' => $this->sendLog]);
+        $this->logger?->info('Email sent', [
+            'recipient' => $recipient,
+            'subject' => $subject,
+        ]);
     }
 }


### PR DESCRIPTION
## Critical: SMTP credentials were being sent to Sentry

Sentry issue **PHP-SYMFONY-2B** accumulated **1034 events**, each carrying the full PhpMailer SMTP debug dump:
- base64-encoded auth password
- Recipient addresses
- Message body

This happened because when `SMTP_DEBUG_LEVEL > 0`, PhpMailer's `Debugoutput` callback was wired to the Symfony logger, which forwarded everything to Sentry at `notice` level.

## Fix
Remove the Debugoutput → logger wiring and the in-memory `sendLog` buffer entirely. Replace it with a single info-level "Email sent" log carrying only `recipient` and `subject`.

`SMTPDebug` still works for local debugging — PhpMailer prints to stdout / error_log by default when no `Debugoutput` callback is set.

## What this does NOT change
- The monolog Sentry handler threshold stays at `notice`
- `SMTP_DEBUG_LEVEL` env var is still honoured (just no longer forwarded through the logger)
- The rotating log file `var/log/log.log` still captures the new info-level log entries

## Follow-ups for the operator
- The existing 1034 PhpMailer Debug events in Sentry still contain the credentials. Purge them via Sentry UI (or the whole issue)
- **Rotate the SMTP password** — it was in plain text in Sentry for 4+ months