### PR TITLE
fix(admin): last-usage modal showed wrong stand on RENT rows

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -217,16 +217,16 @@ function last(bikeNumber) {
                 hour12: false,
             });
 
+            const $template = $("#bike-card-last_usage_template");
             $.each(data.history, function (index, item) {
-                const $template = $("#bike-card-last_usage_template");
-                const $history = $template.clone().removeClass("d-none");
+                const $history = $template.clone().removeAttr("id").removeClass("d-none");
                 const date = new Date(item.time);
-                $history.find("#time").text(isNaN(date.getTime()) ? item.time : dateTimeFormatter.format(date));
-                $history.find("#standName").text(item.standName);
-                $history.find("#userName").text(item.userName);
-                $history.find("#parameter").text(item.parameter ?? '');
-                $history.find("#action i").addClass("d-none");
-                $history.find("#action ." + item.action).removeClass("d-none");
+                $history.find(".time").text(isNaN(date.getTime()) ? item.time : dateTimeFormatter.format(date));
+                $history.find(".standName").text(item.standName ?? '');
+                $history.find(".userName").text(item.userName ?? '');
+                $history.find(".parameter").text(item.parameter ?? '');
+                $history.find(".action i").addClass("d-none");
+                $history.find(".action ." + item.action).removeClass("d-none");
 
                 $container.append($history);
             });

--- a/templates/admin/fleet.html.twig
+++ b/templates/admin/fleet.html.twig
@@ -107,7 +107,7 @@
         </div>
     </div>
     <div class="d-none" id="bike-card-last_usage_template">
-        <span id="action">
+        <span class="action">
             <i class="RENT d-none fas fa-lg fa-forward text-info" aria-hidden="true" title="{{ 'Rent'|trans }}"></i>
             <i class="FORCERENT d-none fas fa-lg fa-fast-forward text-danger" aria-hidden="true" title="{{ 'Force Rent'|trans }}"></i>
             <i class="RETURN d-none fas fa-lg fa-backward text-info" aria-hidden="true" title="{{ 'Return'|trans }}"></i>
@@ -115,10 +115,10 @@
             <i class="REVERT d-none fas fa-lg fa-history text-warning" aria-hidden="true" title="{{ 'Revert'|trans }}"></i>
             <i class="CHANGECODE d-none fas fa-lg fa-key text-primary" aria-hidden="true" title="{{ 'Code updated'|trans }}"></i>
         </span>
-        <span id="time"></span>
-        <span id="standName"></span>
-        <span id="userName"></span>
-        <span id="parameter"></span>
+        <span class="time"></span>
+        <span class="standName"></span>
+        <span class="userName"></span>
+        <span class="parameter"></span>
         <hr/>
     </div>
 


### PR DESCRIPTION
## Summary

Bike *Last usage* modal in admin panel showed an incorrect stand name on every RENT row — always the same name as the first RETURN above it (e.g. RENT 17:56 displayed as `FRANTISKANSKE` although the bike had been returned to `MAGISTRAT` at 18:45).

## Root cause

`public/js/admin.js#last()` clones `<div id="bike-card-last_usage_template">` and appends the clones into `#bikeLastUsage .modal-body`. The clone preserves the `id`, so on the second iteration `$("#bike-card-last_usage_template")` resolves via `document.getElementById` to the **first clone already in the modal body** — not the original template (the modal precedes the template in DOM order).

That clone already carries `<span id="standName">FRANTISKANSKE</span>` from the preceding RETURN render. RENT history items don't carry `standName` in the API payload (`/api/v1/admin/bikes/{N}/last-usage` returns it only on RETURN/REVERT). In jQuery 3.5.1, `$el.text(undefined)` is a getter and doesn't clear the span — so the bled-in value sticks.

Reproduced in JSDOM with the original markup; fix removes the leak.

## Fix

- Convert inner span identifiers from `id` to `class` so duplicates can't collide.
- `removeAttr("id")` on each clone before append.
- Default missing fields to `''` in `.text()` so a row never inherits the previous row's content.
- Hoist `$template` lookup out of the loop (consistency, not behavior).

## Test plan

- [x] JSDOM reproduction confirms RENT rows render with empty stand after the fix.
- [x] `vendor/bin/phpunit --filter BikeLastUsageTest` — 1 test, 43 assertions, OK.
- [ ] Manual: open *Last usage* modal in admin for a bike that has alternating RENT/RETURN history; verify each RENT shows no stand and each RETURN shows the correct stand.