### PR TITLE
chore(db): drop legacy magic methods from PdoDbResult

### DIFF
--- a/src/Db/PdoDbResult.php
+++ b/src/Db/PdoDbResult.php
@@ -55,32 +55,4 @@ class PdoDbResult implements DbResultInterface
     {
         return $this->result ? (int)$this->result->rowCount() : 0;
     }
-
-    /**
-     * @TODO temporary solution, should be removed
-     */
-    public function __call($name, $arguments)
-    {
-        if (method_exists($this->result, $name)) {
-            return call_user_func_array([$this->result, $name], $arguments);
-        } else {
-            throw new \Exception(sprintf('Method %s not found', $name));
-        }
-    }
-
-    /**
-     * @TODO temporary solution, should be removed
-     */
-    public function __get($name)
-    {
-        if ($name === 'num_rows') {
-            return $this->rowCount();
-        } elseif (property_exists($this->result, $name)) {
-            return $this->result->$name;
-        } elseif (property_exists($this, $name)) {
-            return $this->$name;
-        } else {
-            throw new \Exception(sprintf('Property %s not found', $name));
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Removes the two `@TODO temporary solution, should be removed` magic methods on `PdoDbResult`:

- `__call` — proxied unknown method calls to the underlying `PDOStatement`.
- `__get` — exposed `num_rows` (mysqli alias for `rowCount()`) and arbitrary `PDOStatement`/own properties.

Both were carry-overs from the mysqli → PDO migration. Verified that nothing in `src/` or `tests/` relies on them: every caller goes through `DbInterface::query()->{fetchAssoc,fetchAllAssoc,rowCount}` (the three explicit `DbResultInterface` methods). No `num_rows` or `fetch_assoc()` references outside the file itself.

## Test plan

- [x] `vendor/bin/phpunit` — 355 tests, same 1 error / 4 failures as on `main` (auth/login flow pre-existing, unrelated).
- [x] `vendor/bin/phpcs src/Db/` — clean.
- [x] `vendor/bin/phpstan analyse src/Db/` — no errors.