### PR TITLE
feat(stands): manageable status enum with admin editor

### DIFF
--- a/MIGRATION.MD
+++ b/MIGRATION.MD
@@ -26,4 +26,8 @@ CREATE TABLE `userSettings` (
     UNIQUE KEY (`userId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+ALTER TABLE `stands`
+    ADD COLUMN `status` ENUM('active','technical','hidden','inactive') NOT NULL DEFAULT 'active' AFTER `serviceTag`;
+UPDATE `stands` SET `status` = 'technical' WHERE `serviceTag` <> 0;
+ALTER TABLE `stands` DROP COLUMN `serviceTag`;
 ```

--- a/config/routes/api.php
+++ b/config/routes/api.php
@@ -21,6 +21,14 @@ return function (RoutingConfigurator $routes) {
     $routes->add('api_v1_stands', '/api/v1/admin/stands')
         ->methods(['GET'])
         ->controller([\BikeShare\Controller\Api\V1\Admin\StandsController::class, 'index']);
+    $routes->add('api_v1_admin_stand_item_by_id', '/api/v1/admin/stands/{standId}')
+        ->requirements(['standId' => '\d+'])
+        ->methods(['GET'])
+        ->controller([\BikeShare\Controller\Api\V1\Admin\StandsController::class, 'itemById']);
+    $routes->add('api_v1_admin_stand_item_update', '/api/v1/admin/stands/{standId}')
+        ->requirements(['standId' => '\d+'])
+        ->methods(['PATCH'])
+        ->controller([\BikeShare\Controller\Api\V1\Admin\StandsController::class, 'update']);
     $routes->add('api_v1_admin_stand_item', '/api/v1/admin/stands/{standName}')
         ->requirements(['standName' => '\w+'])
         ->methods(['GET'])

--- a/docker-data/mysql/create-database.sql
+++ b/docker-data/mysql/create-database.sql
@@ -153,7 +153,7 @@ CREATE TABLE `stands` (
   `standName` varchar(50) NOT NULL,
   `standDescription` varchar(255),
   `standPhoto` varchar(255),
-  `serviceTag` int(10),
+  `status` ENUM('active','technical','hidden','inactive') NOT NULL DEFAULT 'active',
   `placeName` varchar(50) NOT NULL,
   `longitude` double(20,17),
   `latitude` double(20,17),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -101,6 +101,46 @@ paths:
           $ref: "#/components/responses/Success"
         "404":
           $ref: "#/components/responses/Problem"
+  /admin/stands/{standId}:
+    get:
+      summary: Get stand details by id (admin)
+      parameters:
+        - name: standId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "404":
+          $ref: "#/components/responses/Problem"
+    patch:
+      summary: Update stand status (admin)
+      parameters:
+        - name: standId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum: [active, technical, hidden, inactive]
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "400":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
   /stands/{standName}/bikes:
     get:
       summary: List bikes on stand

--- a/public/css/map.css
+++ b/public/css/map.css
@@ -31,17 +31,24 @@ html, body {
       height: 60px;
       width: 60px;
    }
-   .none {
+   .stand-empty {
       background: url(../img/icon-none.png);
       background-position: 0 0;
       background-size: 60px 60px;
       background-repeat: none;
    }
-   .special {
+   .stand-technical {
       background: url(../img/icon-repair.png);
       background-position: 0 0;
       background-size: 60px 60px;
       background-repeat: none;
+   }
+   .stand-hidden {
+      background: url(../img/icon.png);
+      background-position: 0 0;
+      background-size: 60px 60px;
+      background-repeat: none;
+      filter: hue-rotate(220deg) saturate(2);
    }
 
    .bikecount {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -248,6 +248,7 @@ function generateStandCards(data) {
     $.each(data, function (index, item) {
         const $card = $template.clone().removeAttr("id").removeClass("d-none");
 
+        $card.find(".stand-card").attr("data-stand-id", item.standId);
         $card.find(".stand-name").text(item.standName);
 
         const $photo = $card.find(".stand-photo");
@@ -266,15 +267,58 @@ function generateStandCards(data) {
                 .attr("href", googleMapsUrl);
         }
 
-        if (item.standName.toLowerCase().includes("servis")) {
+        if (item.status === 'technical') {
             $card.find(".service-stand").removeClass("d-none");
-        } else if (item.standName.toLowerCase().includes("zruseny")) {
+        } else if (item.status === 'hidden') {
+            $card.find(".hidden-stand").removeClass("d-none");
+        } else if (item.status === 'inactive') {
             $card.find(".removed-stand").removeClass("d-none");
         }
+
+        $card.find(".stand-status").val(item.status || 'active');
 
         $container.append($card);
     });
 }
+
+$(document).on('click', '.stand-status-save', function () {
+    const $card = $(this).closest('.stand-card');
+    const standId = $card.attr('data-stand-id');
+    const status = $card.find('.stand-status').val();
+    const $feedback = $card.find('.stand-status-feedback');
+
+    $.ajax({
+        url: '/api/v1/admin/stands/' + encodeURIComponent(standId),
+        method: 'PATCH',
+        contentType: 'application/json',
+        dataType: 'json',
+        data: JSON.stringify({status: status}),
+        success: function (response) {
+            const newStatus = (apiData(response) || {}).status || status;
+            $card.find('.service-stand, .hidden-stand, .removed-stand').addClass('d-none');
+            if (newStatus === 'technical') {
+                $card.find('.service-stand').removeClass('d-none');
+            } else if (newStatus === 'hidden') {
+                $card.find('.hidden-stand').removeClass('d-none');
+            } else if (newStatus === 'inactive') {
+                $card.find('.removed-stand').removeClass('d-none');
+            }
+            $feedback
+                .removeClass('d-none text-danger')
+                .addClass('text-success')
+                .text('Saved');
+        },
+        error: function (xhr) {
+            const detail = xhr.responseJSON && xhr.responseJSON.detail
+                ? xhr.responseJSON.detail
+                : 'Failed to save status';
+            $feedback
+                .removeClass('d-none text-success')
+                .addClass('text-danger')
+                .text(detail);
+        }
+    });
+});
 
 function stands(standName) {
     const hasStandName = standName !== undefined && standName !== null && standName !== '';

--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -177,14 +177,17 @@ function getmarkers() {
                 standPhoto,
                 bikeCount,
                 longitude,
-                latitude
+                latitude,
+                status
             } = jsonObject[i];
 
             let iconClass = 'icondesc';
-            if (standName.includes('SERVIS')) {
-                iconClass += ' special';
+            if (status === 'technical') {
+                iconClass += ' stand-technical';
+            } else if (status === 'hidden') {
+                iconClass += ' stand-hidden';
             } else if (bikeCount === 0) {
-                iconClass += ' none';
+                iconClass += ' stand-empty';
             }
 
             const iconHTML = `

--- a/src/App/Api/Compat/AddServiceTagFromStatusTransform.php
+++ b/src/App/Api/Compat/AddServiceTagFromStatusTransform.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\App\Api\Compat;
+
+use BikeShare\Enum\StandStatus;
+
+class AddServiceTagFromStatusTransform implements ApiResponseTransformInterface
+{
+    public function getSinceVersion(): string
+    {
+        return '1.1.2';
+    }
+
+    public function getRoutes(): array
+    {
+        return [
+            'api_v1_stand_markers',
+            'api_v1_stands',
+            'api_v1_admin_stand_item',
+        ];
+    }
+
+    public function transform(array $data): array
+    {
+        return $this->addServiceTagRecursive($data);
+    }
+
+    private function addServiceTagRecursive(array $data): array
+    {
+        if (isset($data['status']) && is_string($data['status'])) {
+            $status = StandStatus::tryFrom($data['status']);
+            $data['serviceTag'] = ($status === StandStatus::TECHNICAL || $status === StandStatus::HIDDEN) ? 1 : 0;
+            return $data;
+        }
+
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $data[$key] = $this->addServiceTagRecursive($value);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/src/Controller/Api/V1/Admin/StandsController.php
+++ b/src/Controller/Api/V1/Admin/StandsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller\Api\V1\Admin;
 
+use BikeShare\Enum\StandStatus;
 use BikeShare\Repository\NoteRepository;
 use BikeShare\Repository\StandRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -32,6 +33,43 @@ class StandsController extends AbstractController
         }
 
         return $this->json($stand);
+    }
+
+    public function itemById(int $standId): Response
+    {
+        $stand = $this->standRepository->findItem($standId);
+        if (empty($stand)) {
+            return $this->json(['detail' => 'Stand not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($stand);
+    }
+
+    public function update(int $standId, Request $request): Response
+    {
+        $stand = $this->standRepository->findItem($standId);
+        if (empty($stand)) {
+            return $this->json(['detail' => 'Stand not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        $payload = $request->getPayload()->all();
+        $status = StandStatus::tryFrom($payload['status'] ?? '');
+        if ($status === null) {
+            return $this->json(['detail' => 'Invalid status'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $previousStatus = $stand['status'];
+        $this->standRepository->updateStatus($standId, $status);
+
+        return $this->json([
+            'message' => sprintf(
+                'Stand %s status changed: %s -> %s',
+                $stand['standName'],
+                $previousStatus,
+                $status->value
+            ),
+            'status' => $status->value,
+        ]);
     }
 
     public function removeNote(

--- a/src/Controller/Api/V1/StandsController.php
+++ b/src/Controller/Api/V1/StandsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller\Api\V1;
 
+use BikeShare\Enum\StandStatus;
 use BikeShare\Repository\NoteRepository;
 use BikeShare\Repository\StandRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -54,10 +55,15 @@ class StandsController extends AbstractController
 
     public function markers(): Response
     {
+        $statuses = [StandStatus::ACTIVE, StandStatus::TECHNICAL];
+        if ($this->isGranted('ROLE_ADMIN')) {
+            $statuses[] = StandStatus::HIDDEN;
+        }
+
         if ($this->isGranted('ROLE_API') && !$this->isGranted('ROLE_USER')) {
-            $stands = $this->standRepository->findAllExtended();
+            $stands = $this->standRepository->findAllExtended(null, $statuses);
         } else {
-            $stands = $this->standRepository->findAllExtended($this->getUser()->getCity());
+            $stands = $this->standRepository->findAllExtended($this->getUser()->getCity(), $statuses);
         }
 
         return $this->json($stands);

--- a/src/Controller/QrCodeGeneratorController.php
+++ b/src/Controller/QrCodeGeneratorController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller;
 
+use BikeShare\Enum\StandStatus;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\StandRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -63,7 +64,7 @@ class QrCodeGeneratorController extends AbstractController
 
         $stands = $standRepository->findAll();
         foreach ($stands as $stand) {
-            if ($stand["serviceTag"] != 0) {
+            if (StandStatus::from($stand["status"]) !== StandStatus::ACTIVE) {
                 continue;
             }
 

--- a/src/Enum/StandStatus.php
+++ b/src/Enum/StandStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Enum;
+
+enum StandStatus: string
+{
+    case ACTIVE = 'active';
+    case TECHNICAL = 'technical';
+    case HIDDEN = 'hidden';
+    case INACTIVE = 'inactive';
+
+    public function isRentablePublic(): bool
+    {
+        return $this === self::ACTIVE;
+    }
+}

--- a/src/EventListener/ControllerEventListener.php
+++ b/src/EventListener/ControllerEventListener.php
@@ -15,6 +15,8 @@ class ControllerEventListener
         'api_v1_stands',
         'api_v1_stand_bikes',
         'api_v1_admin_stand_item',
+        'api_v1_admin_stand_item_by_id',
+        'api_v1_admin_stand_item_update',
         'api_v1_admin_stand_notes_delete',
         'api_v1_admin_bikes',
         'api_v1_bike_item',

--- a/src/EventListener/ResponseEventListener.php
+++ b/src/EventListener/ResponseEventListener.php
@@ -28,6 +28,7 @@ class ResponseEventListener
         'api_v1_coupon_redeem',
         'api_v1_me_city',
         'api_v1_admin_stand_notes_delete',
+        'api_v1_admin_stand_item_update',
     ];
 
     public function __construct(

--- a/src/Rent/AbstractRentSystem.php
+++ b/src/Rent/AbstractRentSystem.php
@@ -88,7 +88,7 @@ abstract class AbstractRentSystem implements RentSystemInterface
                 $stackTopBike = $this->standRepository->findLastReturnedBikeOnStand((int)$standid);
 
                 $stand = $this->standRepository->findItem((int)$standid);
-                $status = StandStatus::from($stand['status']);
+                $status = StandStatus::tryFrom($stand['status'] ?? '') ?? StandStatus::ACTIVE;
 
                 if ($status === StandStatus::INACTIVE) {
                     return $this->error('bike.rent.error.inactive_stand');

--- a/src/Rent/AbstractRentSystem.php
+++ b/src/Rent/AbstractRentSystem.php
@@ -88,7 +88,10 @@ abstract class AbstractRentSystem implements RentSystemInterface
                 $stackTopBike = $this->standRepository->findLastReturnedBikeOnStand((int)$standid);
 
                 $stand = $this->standRepository->findItem((int)$standid);
-                $status = StandStatus::tryFrom($stand['status'] ?? '') ?? StandStatus::ACTIVE;
+                if (empty($stand)) {
+                    return $this->error('bike.rent.error.not_found', ['bikeNumber' => $bikeId]);
+                }
+                $status = StandStatus::from($stand['status']);
 
                 if ($status === StandStatus::INACTIVE) {
                     return $this->error('bike.rent.error.inactive_stand');

--- a/src/Rent/AbstractRentSystem.php
+++ b/src/Rent/AbstractRentSystem.php
@@ -15,6 +15,7 @@ use BikeShare\Repository\NoteRepository;
 use BikeShare\Repository\StandRepository;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Enum\Action;
+use BikeShare\Enum\StandStatus;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\Translation\TranslatableMessage;
@@ -87,9 +88,12 @@ abstract class AbstractRentSystem implements RentSystemInterface
                 $stackTopBike = $this->standRepository->findLastReturnedBikeOnStand((int)$standid);
 
                 $stand = $this->standRepository->findItem((int)$standid);
-                $serviceTag = $stand['serviceTag'] ?? 0;
+                $status = StandStatus::from($stand['status']);
 
-                if ($serviceTag != 0 && ($user['privileges'] ?? 0) < 1) {
+                if ($status === StandStatus::INACTIVE) {
+                    return $this->error('bike.rent.error.inactive_stand');
+                }
+                if (!$status->isRentablePublic() && $user['privileges'] < 1) {
                     return $this->error('bike.rent.error.service_stand');
                 }
 

--- a/src/Repository/BikeRepository.php
+++ b/src/Repository/BikeRepository.php
@@ -4,6 +4,7 @@ namespace BikeShare\Repository;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\Action;
+use BikeShare\Enum\StandStatus;
 
 class BikeRepository
 {
@@ -197,15 +198,16 @@ class BikeRepository
     public function findFreeBikes(): array
     {
         $result = $this->db->query(
-            "SELECT 
+            "SELECT
               count(*) as bikeCount,
               standName
             FROM bikes
-            JOIN stands on bikes.currentStand=stands.standId 
-            WHERE stands.serviceTag=0
-            GROUP BY standName 
-            HAVING bikeCount > 0 
-            ORDER BY 2"
+            JOIN stands on bikes.currentStand=stands.standId
+            WHERE stands.status = :statusActive
+            GROUP BY standName
+            HAVING bikeCount > 0
+            ORDER BY 2",
+            ['statusActive' => StandStatus::ACTIVE->value]
         )->fetchAllAssoc();
 
         return $result;
@@ -295,7 +297,7 @@ class BikeRepository
                 GROUP BY bikeNum
             ) AS movement ON movement.bikeNum = bikes.bikeNum
             WHERE bikes.currentStand IS NOT NULL
-                AND stands.serviceTag = 0
+                AND stands.status IN (:statusActive, :statusHidden)
                 AND movement.lastMoveTime <= :thresholdTime
             ORDER BY movement.lastMoveTime DESC, bikes.bikeNum ASC",
             [
@@ -305,6 +307,8 @@ class BikeRepository
                 'forceRentAction' => Action::FORCE_RENT->value,
                 'forceReturnAction' => Action::FORCE_RETURN->value,
                 'thresholdTime' => $thresholdTime->format('Y-m-d H:i:s'),
+                'statusActive' => StandStatus::ACTIVE->value,
+                'statusHidden' => StandStatus::HIDDEN->value,
             ]
         )->fetchAllAssoc();
 

--- a/src/Repository/StandRepository.php
+++ b/src/Repository/StandRepository.php
@@ -6,6 +6,7 @@ namespace BikeShare\Repository;
 
 use BikeShare\Db\DbInterface;
 use BikeShare\Enum\Action;
+use BikeShare\Enum\StandStatus;
 
 class StandRepository
 {
@@ -16,42 +17,59 @@ class StandRepository
     public function findAll(): array
     {
         $result = $this->db->query(
-            'SELECT
-                    standId,
-                    standName,
-                    standDescription,
-                    standPhoto,
-                    serviceTag,
-                    placeName,
-                    longitude,
-                    latitude
-                FROM stands 
-                ORDER BY standName'
+            "SELECT
+                standId,
+                standName,
+                standDescription,
+                standPhoto,
+                status,
+                placeName,
+                longitude,
+                latitude
+            FROM stands
+            ORDER BY standName"
         )->fetchAllAssoc();
 
         return $result;
     }
 
-    public function findAllExtended($city = null): array
+    /**
+     * @param StandStatus[] $statuses Statuses to include. Defaults to publicly visible (active + technical).
+     */
+    public function findAllExtended(?string $city = null, array $statuses = []): array
     {
+        if (empty($statuses)) {
+            $statuses = [StandStatus::ACTIVE, StandStatus::TECHNICAL];
+        }
+
+        $statusParams = [];
+        $statusPlaceholders = [];
+        foreach ($statuses as $i => $status) {
+            $key = 'status' . $i;
+            $statusParams[$key] = $status->value;
+            $statusPlaceholders[] = ':' . $key;
+        }
+
         $result = $this->db->query(
-            'SELECT
-                 standId,
-                 count(bikeNum) AS bikeCount,
-                 standName,
-                 standDescription,
-                 standPhoto,
-                 longitude,
-                 latitude
-             FROM stands 
-             LEFT JOIN bikes ON bikes.currentStand=stands.standId
-             WHERE stands.serviceTag = 0 ' .
-            (is_null($city) ? ' AND standId != :city ' : ' AND city = :city ') .
-            'GROUP BY standName 
-                 ORDER BY standName',
-            [
-                'city' => (string)$city,
-            ]
+            "SELECT
+                standId,
+                count(bikeNum) AS bikeCount,
+                standName,
+                standDescription,
+                standPhoto,
+                status,
+                longitude,
+                latitude
+            FROM stands
+            LEFT JOIN bikes ON bikes.currentStand=stands.standId
+            WHERE stands.status IN (" . implode(', ', $statusPlaceholders) . ") " .
+            (is_null($city) ? " AND standId != :city " : " AND city = :city ") .
+            "GROUP BY standName
+            ORDER BY standName",
+            array_merge(
+                $statusParams,
+                ['city' => (string)$city]
+            )
         )->fetchAllAssoc();
 
         return $result;
@@ -60,18 +78,18 @@ class StandRepository
     public function findItem(int $standId): ?array
     {
         $stand = $this->db->query(
-            'SELECT
-                    standId,
-                    standName,
-                    standDescription,
-                    standPhoto,
-                    serviceTag,
-                    placeName,
-                    city,
-                    longitude,
-                    latitude
-                FROM stands
-                WHERE standId = :standId',
+            "SELECT
+                standId,
+                standName,
+                standDescription,
+                standPhoto,
+                status,
+                placeName,
+                city,
+                longitude,
+                latitude
+            FROM stands
+            WHERE standId = :standId",
             [
                 'standId' => $standId,
             ]
@@ -83,18 +101,18 @@ class StandRepository
     public function findItemByName(string $standName): ?array
     {
         $stand = $this->db->query(
-            'SELECT
-                    standId,
-                    standName,
-                    standDescription,
-                    standPhoto,
-                    serviceTag,
-                    placeName,
-                    city,
-                    longitude,
-                    latitude
-                FROM stands
-                WHERE standName = :standName LIMIT 1',
+            "SELECT
+                standId,
+                standName,
+                standDescription,
+                standPhoto,
+                status,
+                placeName,
+                city,
+                longitude,
+                latitude
+            FROM stands
+            WHERE standName = :standName LIMIT 1",
             [
                 'standName' => $standName,
             ]
@@ -106,15 +124,16 @@ class StandRepository
     public function findFreeStands(): array
     {
         $result = $this->db->query(
-            "SELECT 
-              count(bikes.bikeNum) as bikeCount,
-              standName
-              FROM stands
-              LEFT JOIN bikes ON bikes.currentStand = stands.standId
-              WHERE stands.serviceTag=0
-              GROUP BY standName
-              HAVING bikeCount = 0
-              ORDER BY 2"
+            "SELECT
+                count(bikes.bikeNum) as bikeCount,
+                standName
+            FROM stands
+            LEFT JOIN bikes ON bikes.currentStand = stands.standId
+            WHERE stands.status = :statusActive
+            GROUP BY standName
+            HAVING bikeCount = 0
+            ORDER BY 2",
+            ['statusActive' => StandStatus::ACTIVE->value]
         )->fetchAllAssoc();
 
         return $result;
@@ -123,7 +142,7 @@ class StandRepository
     public function findLastReturnedBikeOnStand(int $standId): ?int
     {
         $bikesOnStand = $this->db->query(
-            "SELECT bikeNum FROM stands 
+            "SELECT bikeNum FROM stands
             LEFT JOIN bikes ON bikes.currentStand=stands.standId
             WHERE standId=:standId",
             ['standId' => $standId]
@@ -161,12 +180,23 @@ class StandRepository
     public function findBikesOnStand(int $standId): array
     {
         $result = $this->db->query(
-            "SELECT bikeNum FROM bikes 
-             WHERE currentStand=:standId
-             ORDER BY bikeNum",
+            "SELECT bikeNum FROM bikes
+            WHERE currentStand=:standId
+            ORDER BY bikeNum",
             ['standId' => $standId]
         )->fetchAllAssoc();
 
         return $result;
+    }
+
+    public function updateStatus(int $standId, StandStatus $status): void
+    {
+        $this->db->query(
+            "UPDATE stands SET status = :status WHERE standId = :standId",
+            [
+                'status' => $status->value,
+                'standId' => $standId,
+            ]
+        );
     }
 }

--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -6,10 +6,11 @@
             </div>
             {# stand card#}
             <div id="stand-card-template" class="d-none col-md-4 mb-4">
-                <div class="card stand-card border">
+                <div class="card stand-card border" data-stand-id="">
                     <div class="card-header">
                         <span class="stand-name"></span>
                         <i class="fas fa-exclamation-triangle d-none service-stand"></i>
+                        <i class="fas fa-eye-slash d-none hidden-stand"></i>
                         <i class="fas fa-ban d-none removed-stand"></i>
                     </div>
                     <div class="card-body">
@@ -21,6 +22,21 @@
                             {{ 'View on Google Maps'|trans }}
                         </a>
                         <p class="service-warning text-danger font-weight-bold d-none mt-2"></p>
+                        <div class="mt-3">
+                            <label class="form-label small mb-1">{{ 'Status'|trans }}</label>
+                            <div class="input-group input-group-sm">
+                                <select class="stand-status form-select form-select-sm">
+                                    <option value="active">{{ 'Active'|trans }}</option>
+                                    <option value="technical">{{ 'Technical'|trans }}</option>
+                                    <option value="hidden">{{ 'Hidden (testing)'|trans }}</option>
+                                    <option value="inactive">{{ 'Inactive'|trans }}</option>
+                                </select>
+                                <button type="button" class="btn btn-primary stand-status-save">
+                                    {{ 'Save'|trans }}
+                                </button>
+                            </div>
+                            <p class="stand-status-feedback small mt-1 mb-0 d-none"></p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/Application/Controller/Api/Stand/StandMarkersTest.php
+++ b/tests/Application/Controller/Api/Stand/StandMarkersTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 class StandMarkersTest extends BikeSharingWebTestCase
 {
     private const USER_PHONE_NUMBER = '421951111111';
+    private const ADMIN_PHONE_NUMBER = '421951222222';
 
     protected function setUp(): void
     {
@@ -33,6 +34,7 @@ class StandMarkersTest extends BikeSharingWebTestCase
         $this->client->request(Request::METHOD_GET, '/api/v1/stands/markers');
         $this->assertResponseIsSuccessful();
         $response = $this->decodeApiResponseData();
+        $standNames = [];
         foreach ($response as $marker) {
             $this->assertArrayHasKey('standId', $marker, 'Marker does not contain standId');
             $this->assertArrayHasKey('bikeCount', $marker, 'Marker does not contain bikeCount');
@@ -41,7 +43,37 @@ class StandMarkersTest extends BikeSharingWebTestCase
             $this->assertArrayHasKey('standPhoto', $marker, 'Marker does not contain standPhoto');
             $this->assertArrayHasKey('longitude', $marker, 'Marker does not contain longitude');
             $this->assertArrayHasKey('latitude', $marker, 'Marker does not contain latitude');
+            $this->assertArrayHasKey('status', $marker, 'Marker does not contain status');
+            $this->assertContains(
+                $marker['status'],
+                ['active', 'technical'],
+                'Regular user should not see hidden or inactive stands'
+            );
+            $standNames[] = $marker['standName'];
         }
+        $this->assertNotContains('HIDDEN_STAND', $standNames);
+        $this->assertNotContains('INACTIVE_STAND', $standNames);
+    }
+
+    public function testMarkersByAdminIncludeHiddenButNotInactive(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/stands/markers');
+        $this->assertResponseIsSuccessful();
+        $response = $this->decodeApiResponseData();
+
+        $byName = [];
+        foreach ($response as $marker) {
+            $this->assertArrayHasKey('status', $marker);
+            $byName[$marker['standName']] = $marker;
+        }
+
+        $this->assertArrayHasKey('HIDDEN_STAND', $byName, 'Admin should see hidden stand');
+        $this->assertSame('hidden', $byName['HIDDEN_STAND']['status']);
+        $this->assertArrayNotHasKey('INACTIVE_STAND', $byName, 'Admin should not see inactive stand');
     }
 
     public function testMarkersByToken(): void
@@ -61,6 +93,52 @@ class StandMarkersTest extends BikeSharingWebTestCase
             $this->assertArrayHasKey('standPhoto', $marker, 'Marker does not contain standPhoto');
             $this->assertArrayHasKey('longitude', $marker, 'Marker does not contain longitude');
             $this->assertArrayHasKey('latitude', $marker, 'Marker does not contain latitude');
+            $this->assertArrayHasKey('status', $marker, 'Marker does not contain status');
+        }
+    }
+
+    public function testLegacyAndroidClientReceivesServiceTagBackport(): void
+    {
+        $user = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::USER_PHONE_NUMBER);
+        $this->client->loginUser($user);
+
+        $this->client->request(
+            Request::METHOD_GET,
+            '/api/v1/stands/markers',
+            server: ['HTTP_USER_AGENT' => 'okhttp/4.12.0']
+        );
+        $this->assertResponseIsSuccessful();
+        $response = $this->decodeApiResponseData();
+        $this->assertNotEmpty($response);
+        foreach ($response as $marker) {
+            $this->assertArrayHasKey('serviceTag', $marker, 'Legacy client should receive serviceTag');
+            $this->assertArrayHasKey('status', $marker);
+            if ($marker['status'] === 'technical' || $marker['status'] === 'hidden') {
+                $this->assertSame(1, $marker['serviceTag']);
+            } else {
+                $this->assertSame(0, $marker['serviceTag']);
+            }
+        }
+    }
+
+    public function testNewAndroidClientDoesNotReceiveServiceTag(): void
+    {
+        $user = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::USER_PHONE_NUMBER);
+        $this->client->loginUser($user);
+
+        $this->client->request(
+            Request::METHOD_GET,
+            '/api/v1/stands/markers',
+            server: ['HTTP_USER_AGENT' => 'OpenSourceBikeShare-Android/1.1.2 (1)']
+        );
+        $this->assertResponseIsSuccessful();
+        $response = $this->decodeApiResponseData();
+        $this->assertNotEmpty($response);
+        foreach ($response as $marker) {
+            $this->assertArrayNotHasKey('serviceTag', $marker, 'New client should not receive legacy serviceTag');
+            $this->assertArrayHasKey('status', $marker);
         }
     }
 

--- a/tests/Application/Controller/Api/Stand/StandUpdateStatusTest.php
+++ b/tests/Application/Controller/Api/Stand/StandUpdateStatusTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Controller\Api\Stand;
+
+use BikeShare\App\Security\UserProvider;
+use BikeShare\Db\DbInterface;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class StandUpdateStatusTest extends BikeSharingWebTestCase
+{
+    private const ADMIN_PHONE_NUMBER = '421951222222';
+    private const USER_PHONE_NUMBER = '421951111111';
+    private const STAND_ID = 1;
+
+    protected function tearDown(): void
+    {
+        $db = $this->client->getContainer()->get(DbInterface::class);
+        $db->query(
+            'UPDATE stands SET status = :status WHERE standId = :standId',
+            ['status' => 'active', 'standId' => self::STAND_ID]
+        );
+
+        parent::tearDown();
+    }
+
+    public function testUpdateStatusToTechnical(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        $this->client->request(
+            Request::METHOD_PATCH,
+            '/api/v1/admin/stands/' . self::STAND_ID,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['status' => 'technical'])
+        );
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decodeApiResponseData();
+        $this->assertSame('technical', $response['status']);
+        $this->assertArrayHasKey('message', $response);
+
+        $db = $this->client->getContainer()->get(DbInterface::class);
+        $row = $db->query(
+            'SELECT status FROM stands WHERE standId = :standId',
+            ['standId' => self::STAND_ID]
+        )->fetchAssoc();
+        $this->assertSame('technical', $row['status']);
+
+        $received = $db->query(
+            'SELECT * FROM received WHERE sender = :sender ORDER BY receive_time DESC, id DESC LIMIT 1',
+            ['sender' => self::ADMIN_PHONE_NUMBER]
+        )->fetchAssoc();
+        $this->assertSame(
+            '/api/v1/admin/stands/' . self::STAND_ID,
+            $received['sms_text'],
+            'PATCH request was not logged in received table'
+        );
+
+        $sent = $db->query(
+            'SELECT * FROM sent WHERE number = :number ORDER BY time DESC, id DESC LIMIT 1',
+            ['number' => self::ADMIN_PHONE_NUMBER]
+        )->fetchAssoc();
+        $this->assertStringContainsString('active -> technical', $sent['text'], 'Sent log missing status transition');
+        $this->assertStringContainsString('STAND1', $sent['text'], 'Sent log missing stand name');
+    }
+
+    public function testUpdateStatusAcceptsAllValidValues(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        foreach (['technical', 'hidden', 'inactive', 'active'] as $status) {
+            $this->client->request(
+                Request::METHOD_PATCH,
+                '/api/v1/admin/stands/' . self::STAND_ID,
+                server: ['CONTENT_TYPE' => 'application/json'],
+                content: json_encode(['status' => $status])
+            );
+            $this->assertResponseIsSuccessful();
+            $response = $this->decodeApiResponseData();
+            $this->assertSame($status, $response['status']);
+        }
+    }
+
+    public function testUpdateStatusRejectsInvalidStatus(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        $this->client->request(
+            Request::METHOD_PATCH,
+            '/api/v1/admin/stands/' . self::STAND_ID,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['status' => 'banana'])
+        );
+
+        $this->assertResponseStatusCodeSame(400);
+    }
+
+    public function testUpdateStatusReturns404ForUnknownStand(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        $this->client->request(
+            Request::METHOD_PATCH,
+            '/api/v1/admin/stands/9999',
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['status' => 'active'])
+        );
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testUpdateStatusForbiddenForRegularUser(): void
+    {
+        $user = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::USER_PHONE_NUMBER);
+        $this->client->loginUser($user);
+
+        $this->client->request(
+            Request::METHOD_PATCH,
+            '/api/v1/admin/stands/' . self::STAND_ID,
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: json_encode(['status' => 'inactive'])
+        );
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testGetStandById(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/admin/stands/' . self::STAND_ID);
+
+        $this->assertResponseIsSuccessful();
+        $response = $this->decodeApiResponseData();
+        $this->assertSame(self::STAND_ID, $response['standId']);
+        $this->assertArrayHasKey('standName', $response);
+        $this->assertArrayHasKey('status', $response);
+    }
+
+    public function testGetStandByIdReturns404ForUnknownId(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/admin/stands/9999');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
+++ b/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
@@ -23,9 +23,11 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
     private const BIKE_INACTIVE_SHORT = 21;
     private const BIKE_INACTIVE_LONG = 22;
     private const BIKE_ON_SERVICE_STAND = 23;
+    private const BIKE_ON_HIDDEN_STAND = 24;
     private const STAND1_NAME = 'STAND1';
     private const STAND2_NAME = 'STAND2';
     private const SERVICE_STAND_NAME = 'SERVICE_STAND';
+    private const HIDDEN_STAND_NAME = 'HIDDEN_STAND';
 
     private int $adminUserId;
 
@@ -40,6 +42,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
         $this->simulateBikeActivity(self::BIKE_INACTIVE_SHORT, self::STAND1_NAME, '2030-02-05 10:00:00');
         $this->simulateBikeActivity(self::BIKE_INACTIVE_LONG, self::STAND2_NAME, '2030-01-15 10:00:00');
         $this->simulateBikeActivity(self::BIKE_ON_SERVICE_STAND, self::SERVICE_STAND_NAME, '2030-01-20 10:00:00');
+        $this->simulateBikeActivity(self::BIKE_ON_HIDDEN_STAND, self::HIDDEN_STAND_NAME, '2030-01-25 10:00:00');
         static::mockTime('2030-02-15 12:00:00');
     }
 
@@ -73,6 +76,11 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
             strpos($message, self::BIKE_INACTIVE_SHORT . ' | STAND1')
         );
 
+        $this->assertStringContainsString(
+            self::BIKE_ON_HIDDEN_STAND . ' | ' . self::HIDDEN_STAND_NAME,
+            $message,
+            'Bikes on hidden stands should be reported'
+        );
         $this->assertStringNotContainsString('- ' . self::BIKE_ON_SERVICE_STAND . ' |', $message);
 
         $smsConnector = self::getContainer()->get(SmsConnectorInterface::class);
@@ -113,7 +121,13 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
         static::mockTime('2000-01-01 00:00:00');
 
         $rentSystem = self::getContainer()->get(RentSystemFactory::class)->getRentSystem(RentSystemType::WEB);
-        foreach ([self::BIKE_INACTIVE_SHORT, self::BIKE_INACTIVE_LONG, self::BIKE_ON_SERVICE_STAND] as $bikeNumber) {
+        $bikes = [
+            self::BIKE_INACTIVE_SHORT,
+            self::BIKE_INACTIVE_LONG,
+            self::BIKE_ON_SERVICE_STAND,
+            self::BIKE_ON_HIDDEN_STAND,
+        ];
+        foreach ($bikes as $bikeNumber) {
             $rentSystem->returnBike($this->adminUserId, $bikeNumber, self::SERVICE_STAND_NAME, '', true);
         }
     }

--- a/tests/Integration/Rent/RentSystemTest.php
+++ b/tests/Integration/Rent/RentSystemTest.php
@@ -390,4 +390,60 @@ class RentSystemTest extends BikeSharingKernelTestCase
             true
         );
     }
+
+    public function testAdminCanRentBikeFromHiddenStand(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $rentSystemFactory = $container->get(RentSystemFactory::class);
+        $userRepository = $container->get(UserRepository::class);
+
+        $admin = $userRepository->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
+        $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
+
+        $rentSystem = $rentSystemFactory->getRentSystem(RentSystemType::WEB);
+        $rentSystem->returnBike($admin['userId'], self::BIKE_NUMBER, 'HIDDEN_STAND', '', true);
+
+        $userResponse = $rentSystem->rentBike($user['userId'], self::BIKE_NUMBER);
+        $this->assertSame('bike.rent.error.service_stand', $userResponse->getCode());
+
+        $adminWebResponse = $rentSystem->rentBike($admin['userId'], self::BIKE_NUMBER);
+        $this->assertSame('bike.rent.success', $adminWebResponse->getCode());
+
+        $rentSystem->returnBike(
+            $admin['userId'],
+            self::BIKE_NUMBER,
+            self::STAND_NAME,
+            '',
+            true
+        );
+    }
+
+    public function testNobodyCanRentBikeFromInactiveStand(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $rentSystemFactory = $container->get(RentSystemFactory::class);
+        $userRepository = $container->get(UserRepository::class);
+
+        $admin = $userRepository->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
+        $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
+
+        $rentSystem = $rentSystemFactory->getRentSystem(RentSystemType::WEB);
+        $rentSystem->returnBike($admin['userId'], self::BIKE_NUMBER, 'INACTIVE_STAND', '', true);
+
+        $userResponse = $rentSystem->rentBike($user['userId'], self::BIKE_NUMBER);
+        $this->assertSame('bike.rent.error.inactive_stand', $userResponse->getCode());
+
+        $adminResponse = $rentSystem->rentBike($admin['userId'], self::BIKE_NUMBER);
+        $this->assertSame('bike.rent.error.inactive_stand', $adminResponse->getCode());
+
+        $rentSystem->returnBike(
+            $admin['userId'],
+            self::BIKE_NUMBER,
+            self::STAND_NAME,
+            '',
+            true
+        );
+    }
 }

--- a/tests/Integration/Security/RoutesAccessTest.php
+++ b/tests/Integration/Security/RoutesAccessTest.php
@@ -21,6 +21,7 @@ class RoutesAccessTest extends BikeSharingKernelTestCase
         '/api/v1/admin/reports/inactive-bikes' => Request::METHOD_GET,
         '/api/v1/admin/reports/users/2025' => Request::METHOD_GET,
         '/api/v1/admin/stands' => Request::METHOD_GET,
+        '/api/v1/admin/stands/1' => Request::METHOD_PATCH,
         '/api/v1/admin/users' => Request::METHOD_GET,
         '/api/v1/admin/users/1' => Request::METHOD_GET,
     ];

--- a/tests/Unit/App/Api/Compat/AddServiceTagFromStatusTransformTest.php
+++ b/tests/Unit/App/Api/Compat/AddServiceTagFromStatusTransformTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Unit\App\Api\Compat;
+
+use BikeShare\App\Api\Compat\AddServiceTagFromStatusTransform;
+use PHPUnit\Framework\TestCase;
+
+class AddServiceTagFromStatusTransformTest extends TestCase
+{
+    private AddServiceTagFromStatusTransform $transform;
+
+    protected function setUp(): void
+    {
+        $this->transform = new AddServiceTagFromStatusTransform();
+    }
+
+    public function testSinceVersion(): void
+    {
+        $this->assertSame('1.1.2', $this->transform->getSinceVersion());
+    }
+
+    public function testRoutesAreSpecific(): void
+    {
+        $routes = $this->transform->getRoutes();
+        $this->assertNotEmpty($routes);
+        $this->assertContains('api_v1_stand_markers', $routes);
+        $this->assertContains('api_v1_stands', $routes);
+        $this->assertContains('api_v1_admin_stand_item', $routes);
+    }
+
+    public function testActiveStatusMapsToZeroServiceTag(): void
+    {
+        $data = [
+            ['standId' => 1, 'standName' => 'STAND1', 'status' => 'active'],
+        ];
+
+        $result = $this->transform->transform($data);
+
+        $this->assertSame(0, $result[0]['serviceTag']);
+        $this->assertSame('active', $result[0]['status']);
+    }
+
+    public function testTechnicalStatusMapsToOne(): void
+    {
+        $data = [['standId' => 6, 'status' => 'technical']];
+        $result = $this->transform->transform($data);
+        $this->assertSame(1, $result[0]['serviceTag']);
+    }
+
+    public function testHiddenStatusMapsToOne(): void
+    {
+        $data = [['standId' => 7, 'status' => 'hidden']];
+        $result = $this->transform->transform($data);
+        $this->assertSame(1, $result[0]['serviceTag']);
+    }
+
+    public function testSingleObjectIsTransformed(): void
+    {
+        $data = ['standId' => 1, 'standName' => 'STAND1', 'status' => 'active'];
+        $result = $this->transform->transform($data);
+        $this->assertSame(0, $result['serviceTag']);
+    }
+
+    public function testNestedArraysAreTransformed(): void
+    {
+        $data = [
+            'wrapper' => [
+                ['status' => 'technical', 'standName' => 'A'],
+                ['status' => 'active', 'standName' => 'B'],
+            ],
+        ];
+
+        $result = $this->transform->transform($data);
+
+        $this->assertSame(1, $result['wrapper'][0]['serviceTag']);
+        $this->assertSame(0, $result['wrapper'][1]['serviceTag']);
+    }
+
+    public function testItemsWithoutStatusAreLeftAlone(): void
+    {
+        $data = [['unrelated' => 'value']];
+        $result = $this->transform->transform($data);
+        $this->assertArrayNotHasKey('serviceTag', $result[0]);
+    }
+}

--- a/tests/fixtures/stands.yaml
+++ b/tests/fixtures/stands.yaml
@@ -5,7 +5,7 @@ stdClass:
     standName (unique): 'Default Stand'
     standDescription: 'Default Stand Description'
     standPhoto: ''
-    serviceTag: '0'
+    status: 'active'
     placeName: 'Default Place'
     longitude (unique): '<latitude(17.05, 17.15)>'
     latitude (unique): '<longitude(48.10, 48.20)>'
@@ -20,4 +20,16 @@ stdClass:
     standId: '6'
     standName: 'SERVICE_STAND'
     standDescription: '<streetName()>'
-    serviceTag: '1'
+    status: 'technical'
+
+  stand_hidden (extends defaultStand):
+    standId: '7'
+    standName: 'HIDDEN_STAND'
+    standDescription: '<streetName()>'
+    status: 'hidden'
+
+  stand_inactive (extends defaultStand):
+    standId: '8'
+    standName: 'INACTIVE_STAND'
+    standDescription: '<streetName()>'
+    status: 'inactive'

--- a/translations/rentSystem+intl-icu.cs.php
+++ b/translations/rentSystem+intl-icu.cs.php
@@ -23,6 +23,7 @@ other {<h3>Kolo <span class="badge badge-primary">{bikeNumber}</span> vráceno n
     'bike.rent.error.zero_limit' => 'Nemůžete si půjčit žádná kola. Kontaktujte administrátory, aby zrušili zákaz.',
     'bike.rent.error.limit' => 'Můžete si najednou půjčit pouze {count, plural, one {# kolo} few {# kola} other {# kol}}.',
     'bike.rent.error.service_stand' => 'Půjčování ze servisních stojanů není povoleno: Kolo pravděpodobně čeká na opravu.',
+    'bike.rent.error.inactive_stand' => 'Půjčování z neaktivních stojanů není povoleno.',
     'bike.rent.error.stack_top_bike' => 'Kolo {bikeNumber} není momentálně možné si půjčit, musíte si půjčit kolo {stackTopBike} z tohoto stojanu.',
 
     'bike.return.error.stand_not_found' => 'Název stojanu \'{standName}\' neexistuje. Stojany jsou označeny VELKÝMI PÍSMENY.',

--- a/translations/rentSystem+intl-icu.de.php
+++ b/translations/rentSystem+intl-icu.de.php
@@ -23,6 +23,7 @@ other {<h3>Fahrrad <span class="badge badge-primary">{bikeNumber}</span> wurde z
     'bike.rent.error.zero_limit' => 'Du kannst keine Fahrräder ausleihen. Wende dich an die Administratoren, um die Sperre aufzuheben.',
     'bike.rent.error.limit' => 'Du kannst nur {count, plural, one {# Fahrrad} other {# Fahrräder}} gleichzeitig ausleihen.',
     'bike.rent.error.service_stand' => 'Ausleihen von Service-Ständern ist nicht erlaubt: Das Fahrrad wartet wahrscheinlich auf eine Reparatur.',
+    'bike.rent.error.inactive_stand' => 'Ausleihen von inaktiven Ständern ist nicht erlaubt.',
     'bike.rent.error.stack_top_bike' => 'Fahrrad {bikeNumber} kann derzeit nicht ausgeliehen werden, du musst Fahrrad {stackTopBike} von diesem Ständer ausleihen.',
 
     'bike.return.error.stand_not_found' => 'Standname \'{standName}\' existiert nicht. Stände sind mit GROSSBUCHSTABEN markiert.',

--- a/translations/rentSystem+intl-icu.en.php
+++ b/translations/rentSystem+intl-icu.en.php
@@ -29,6 +29,7 @@ other {<h3>Bike <span class="badge badge-primary">{bikeNumber}</span> reverted t
     'bike.rent.error.zero_limit' => 'You can not rent any bikes. Contact the admins to lift the ban.',
     'bike.rent.error.limit' => 'You can only rent {count, plural, one {# bike} other {# bikes}} at once.',
     'bike.rent.error.service_stand' => 'Renting from service stands is not allowed: The bike probably waits for a repair.',
+    'bike.rent.error.inactive_stand' => 'Renting from inactive stands is not allowed.',
     'bike.rent.error.stack_top_bike' => 'Bike {bikeNumber} is not rentable now, you have to rent bike {stackTopBike} from this stand.',
 
     'bike.return.error.stand_not_found' => 'Stand name \'{standName}\' does not exist. Stands are marked by CAPITALLETTERS.',

--- a/translations/rentSystem+intl-icu.sk.php
+++ b/translations/rentSystem+intl-icu.sk.php
@@ -23,6 +23,7 @@ other {<h3>Bicykel <span class="badge badge-primary">{bikeNumber}</span> vráten
     'bike.rent.error.zero_limit' => 'Nemôžete si požičať žiadne bicykle. Kontaktujte administrátorov, aby zrušili zákaz.',
     'bike.rent.error.limit' => 'Môžete si naraz požičať len {count, plural, one {# bicykel} few {# bicykle} other {# bicyklov}}.',
     'bike.rent.error.service_stand' => 'Požičiavanie zo servisných stojanov nie je povolené: Bicykel pravdepodobne čaká na opravu.',
+    'bike.rent.error.inactive_stand' => 'Požičiavanie z neaktívnych stojanov nie je povolené.',
     'bike.rent.error.stack_top_bike' => 'Bicykel {bikeNumber} momentálne nie je možné si požičať, musíte si požičať bicykel {stackTopBike} z tohto stojanu.',
 
     'bike.return.error.stand_not_found' => 'Názov stojanu \'{standName}\' neexistuje. Stojany sú označené VEĽKÝMI PÍSMENAMI.',

--- a/translations/rentSystem+intl-icu.uk.php
+++ b/translations/rentSystem+intl-icu.uk.php
@@ -23,6 +23,7 @@ other {<h3>Велосипед <span class="badge badge-primary">{bikeNumber}</sp
     'bike.rent.error.zero_limit' => 'Ви не можете орендувати велосипеди. Зверніться до адміністраторів, щоб зняти заборону.',
     'bike.rent.error.limit' => 'Ви можете орендувати одночасно лише {count, plural, one {# велосипед} few {# велосипеди} other {# велосипедів}}.',
     'bike.rent.error.service_stand' => 'Оренда зі сервісних стоянок не дозволена: велосипед, ймовірно, чекає на ремонт.',
+    'bike.rent.error.inactive_stand' => 'Оренда з неактивних стоянок не дозволена.',
     'bike.rent.error.stack_top_bike' => 'Велосипед {bikeNumber} зараз неможливо орендувати, ви маєте орендувати велосипед {stackTopBike} з цієї стоянки.',
 
     'bike.return.error.stand_not_found' => 'Назва стоянки \'{standName}\' не існує. Стоянки позначені ВЕЛИКИМИ ЛІТЕРАМИ.',


### PR DESCRIPTION
## Summary

- Replace binary `serviceTag` on stands with four-value `status` ENUM: **active**, **technical**, **hidden** (testing-only, visible to admins on map), **inactive** (soft-disabled).
- Admins manage status through a new dropdown on the stands admin tab and `PATCH /api/v1/admin/stands/{standId}`.
- Backwards-compat: legacy Android clients (<1.1.2) keep receiving `serviceTag` via the existing `ApiResponseTransformInterface` mechanism — new `AddServiceTagFromStatusTransform`.

## Changes

**Schema & enum**
- `docker-data/mysql/create-database.sql` — `status` ENUM replaces `serviceTag`; default `active`, NOT NULL.
- `MIGRATION.MD` — ALTER scripts for prod.
- `src/Enum/StandStatus.php` — backed string enum with `isRentablePublic()` helper.

**Backend**
- `StandRepository::findAllExtended(?city, StandStatus[] $statuses = [])` — role-agnostic, callers pass the visibility set; default is publicly visible (`active+technical`). Removed `findAllExtendedForAdmin` — extending visibility for new roles is now a one-line change in the controller.
- `StandsController::markers()` — adds `HIDDEN` for `ROLE_ADMIN`, otherwise public set.
- `Admin/StandsController` — new `update($standId)` (PATCH) and `itemById($standId)` (GET) alongside the existing name-based GET. Audit via existing `received`/`sent` event listeners; response message records `old -> new` transition.
- `AbstractRentSystem` — gates rentals: inactive blocks everyone (new key `bike.rent.error.inactive_stand`), technical/hidden block non-admins via existing `service_stand` error.
- `BikeRepository::findInactiveBikes` — now also includes bikes parked on hidden stands (testing pipeline).
- `QrCodeGeneratorController` — skips non-active stands when generating bulk QR codes.
- All status-related SQL uses placeholders bound from `StandStatus::*->value` (no string literals in SQL).

**Frontend (web)**
- `public/js/functions.js` — status-driven CSS classes (`.stand-technical`, `.stand-hidden`, `.stand-empty`); replaces fragile name-based `SERVIS` detection.
- `public/css/map.css` — `.stand-hidden` uses `hue-rotate` filter on the default icon (no new asset needed).
- `templates/admin/stands.html.twig` + `public/js/admin.js` — status dropdown + Save button; in-place card update on PATCH success.

**Backwards compatibility**
- `src/App/Api/Compat/AddServiceTagFromStatusTransform.php` (since 1.1.2) — injects derived `serviceTag` into stand responses for clients on older Android versions, detected by UA via existing `ClientVersionDetector`. Schedule trans removal as a separate PR after 2-3 Android release cycles.

**Translations**
- New `bike.rent.error.inactive_stand` key for cs/de/en/sk/uk.

**OpenAPI**
- New PATCH and GET-by-id routes documented under `/admin/stands/{standId}`.

## Notes for the Android side

A follow-up bump to **1.1.2** in `OpenSourceBikeShare-Android` is needed to:
- replace `StandMarkerDto.serviceTag`/`StandDetailDto.serviceTag` with `status: String`,
- update `MapScreen.kt` marker rendering to use the new statuses,
- add `PATCH /admin/stands/{id}` to `ApiService` for admin status edits.

Older installed app versions (incl. those without custom UA) keep working unchanged thanks to the API compat transform.

## Test plan

- [x] PHPUnit: 380/380 passing in Docker, including new tests:
  - `StandMarkersTest` — admin/user visibility, legacy `okhttp/*` UA receives `serviceTag`, modern UA does not.
  - `StandUpdateStatusTest` — PATCH 200/400/404/403, GET-by-id 200/404, audit row in `received`, transition message in `sent`.
  - `Unit/App/Api/Compat/AddServiceTagFromStatusTransformTest` — mapping rules.
  - `RentSystemTest` — admin can rent from hidden, nobody can rent from inactive.
  - `InactiveStandBikesCheckCommandTest` — bikes on hidden stands appear in the report; bikes on technical do not.
- [x] phpcs clean
- [x] yaml-lint on `openapi.yaml` clean
- [ ] Manual: load fixtures, log in as user → no HIDDEN/INACTIVE on map; log in as admin → HIDDEN visible with distinct icon, status dropdown saves, marker re-renders without page reload.
- [ ] Manual: hit `/api/v1/stands/markers` with `User-Agent: okhttp/4.12.0` → response contains both `status` and `serviceTag`; with `OpenSourceBikeShare-Android/1.1.2 (1)` → only `status`.