### PR TITLE
feat(admin): color-coded stand cards and status filter

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -240,45 +240,80 @@ function last(bikeNumber) {
     });
 }
 
+const STAND_STATUS_BORDER = {
+    active: 'border-success',
+    technical: 'border-warning',
+    hidden: 'border-info',
+    inactive: 'border-secondary',
+};
+
+function applyStandStatusToCard($card, status) {
+    Object.values(STAND_STATUS_BORDER).forEach(cls => $card.removeClass(cls));
+    $card.removeClass('opacity-50');
+    $card.addClass(STAND_STATUS_BORDER[status] || STAND_STATUS_BORDER.active);
+    if (status === 'inactive') {
+        $card.addClass('opacity-50');
+    }
+    $card.attr('data-status', status);
+
+    $card.find('.service-stand, .hidden-stand, .removed-stand').addClass('d-none');
+    if (status === 'technical') {
+        $card.find('.service-stand').removeClass('d-none');
+    } else if (status === 'hidden') {
+        $card.find('.hidden-stand').removeClass('d-none');
+    } else if (status === 'inactive') {
+        $card.find('.removed-stand').removeClass('d-none');
+    }
+}
+
+function applyStandStatusFilter() {
+    const enabled = $('.stand-status-filter .btn-check:checked')
+        .map(function () { return this.value; })
+        .get();
+    $('#standsconsole > .col-md-4').each(function () {
+        const status = $(this).find('.stand-card').attr('data-status') || 'active';
+        $(this).toggle(enabled.includes(status));
+    });
+}
+
+$(document).on('change', '.stand-status-filter .btn-check', applyStandStatusFilter);
+
 function generateStandCards(data) {
     const $container = $("#standsconsole");
     const $template = $("#stand-card-template");
     $container.empty();
 
     $.each(data, function (index, item) {
-        const $card = $template.clone().removeAttr("id").removeClass("d-none");
+        const $col = $template.clone().removeAttr("id").removeClass("d-none");
+        const $card = $col.find('.stand-card');
+        const status = item.status || 'active';
 
-        $card.find(".stand-card").attr("data-stand-id", item.standId);
-        $card.find(".stand-name").text(item.standName);
+        $card.attr("data-stand-id", item.standId);
+        $col.find(".stand-name").text(item.standName);
 
-        const $photo = $card.find(".stand-photo");
+        const $photo = $col.find(".stand-photo");
         if (item.standPhoto) {
             $photo.attr("src", item.standPhoto).removeClass("d-none");
         } else {
             $photo.addClass("d-none");
         }
 
-        $card.find(".stand-description").text(item.standDescription);
+        $col.find(".stand-description").text(item.standDescription);
 
         if (parseInt(item.latitude) !== 0 && parseInt(item.longitude) !== 0) {
             const googleMapsUrl = `https://www.google.com/maps?q=${item.latitude},${item.longitude}`;
-            $card.find(".stand-location")
+            $col.find(".stand-location")
                 .removeClass("d-none")
                 .attr("href", googleMapsUrl);
         }
 
-        if (item.status === 'technical') {
-            $card.find(".service-stand").removeClass("d-none");
-        } else if (item.status === 'hidden') {
-            $card.find(".hidden-stand").removeClass("d-none");
-        } else if (item.status === 'inactive') {
-            $card.find(".removed-stand").removeClass("d-none");
-        }
+        applyStandStatusToCard($card, status);
+        $col.find(".stand-status").val(status);
 
-        $card.find(".stand-status").val(item.status || 'active');
-
-        $container.append($card);
+        $container.append($col);
     });
+
+    applyStandStatusFilter();
 }
 
 $(document).on('click', '.stand-status-save', function () {
@@ -295,14 +330,8 @@ $(document).on('click', '.stand-status-save', function () {
         data: JSON.stringify({status: status}),
         success: function (response) {
             const newStatus = (apiData(response) || {}).status || status;
-            $card.find('.service-stand, .hidden-stand, .removed-stand').addClass('d-none');
-            if (newStatus === 'technical') {
-                $card.find('.service-stand').removeClass('d-none');
-            } else if (newStatus === 'hidden') {
-                $card.find('.hidden-stand').removeClass('d-none');
-            } else if (newStatus === 'inactive') {
-                $card.find('.removed-stand').removeClass('d-none');
-            }
+            applyStandStatusToCard($card, newStatus);
+            applyStandStatusFilter();
             $feedback
                 .removeClass('d-none text-danger')
                 .addClass('text-success')

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -246,15 +246,19 @@ const STAND_STATUS_BORDER = {
     hidden: 'border-info',
     inactive: 'border-secondary',
 };
+const STAND_STATUS_BORDER_CLASSES = Object.values(STAND_STATUS_BORDER).join(' ');
+const STAND_STATUS_DIMMED_SELECTOR = '.card-header, .stand-description';
+const STAND_STATUS_FILTER_STORAGE_KEY = 'admin.stands.statusFilter';
 
 function applyStandStatusToCard($card, status) {
-    Object.values(STAND_STATUS_BORDER).forEach(cls => $card.removeClass(cls));
-    $card.removeClass('opacity-50');
-    $card.addClass(STAND_STATUS_BORDER[status] || STAND_STATUS_BORDER.active);
-    if (status === 'inactive') {
-        $card.addClass('opacity-50');
+    $card.removeClass(STAND_STATUS_BORDER_CLASSES);
+    $card.find(STAND_STATUS_DIMMED_SELECTOR).removeClass('opacity-50');
+    if (STAND_STATUS_BORDER[status]) {
+        $card.addClass(STAND_STATUS_BORDER[status]);
     }
-    $card.attr('data-status', status);
+    if (status === 'inactive') {
+        $card.find(STAND_STATUS_DIMMED_SELECTOR).addClass('opacity-50');
+    }
 
     $card.find('.service-stand, .hidden-stand, .removed-stand').addClass('d-none');
     if (status === 'technical') {
@@ -270,13 +274,42 @@ function applyStandStatusFilter() {
     const enabled = $('.stand-status-filter .btn-check:checked')
         .map(function () { return this.value; })
         .get();
-    $('#standsconsole > .col-md-4').each(function () {
-        const status = $(this).find('.stand-card').attr('data-status') || 'active';
+    $('#standsconsole > .stand-col').each(function () {
+        const status = $(this).find('.stand-status').val() || 'active';
         $(this).toggle(enabled.includes(status));
     });
 }
 
-$(document).on('change', '.stand-status-filter .btn-check', applyStandStatusFilter);
+function loadStandStatusFilter() {
+    const saved = localStorage.getItem(STAND_STATUS_FILTER_STORAGE_KEY);
+    if (saved === null) return;
+    let enabled;
+    try {
+        enabled = JSON.parse(saved);
+    } catch (e) {
+        return;
+    }
+    if (!Array.isArray(enabled)) return;
+    $('.stand-status-filter .btn-check').each(function () {
+        $(this).prop('checked', enabled.includes(this.value));
+    });
+}
+
+function saveStandStatusFilter() {
+    const enabled = $('.stand-status-filter .btn-check:checked')
+        .map(function () { return this.value; })
+        .get();
+    localStorage.setItem(STAND_STATUS_FILTER_STORAGE_KEY, JSON.stringify(enabled));
+}
+
+$(document).on('change', '.stand-status-filter .btn-check', function () {
+    saveStandStatusFilter();
+    applyStandStatusFilter();
+});
+
+$(function () {
+    loadStandStatusFilter();
+});
 
 function generateStandCards(data) {
     const $container = $("#standsconsole");

--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -18,7 +18,7 @@
 
             </div>
             {# stand card#}
-            <div id="stand-card-template" class="d-none col-md-4 mb-4">
+            <div id="stand-card-template" class="d-none col-md-4 mb-4 stand-col">
                 <div class="card stand-card border" data-stand-id="">
                     <div class="card-header">
                         <span class="stand-name"></span>

--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -1,6 +1,19 @@
 {% block stands %}
     <div class="row">
         <div class="col-lg-12 mt-3">
+            <div class="btn-group btn-group-sm mb-3 stand-status-filter" role="group">
+                <input type="checkbox" class="btn-check" id="stand-filter-active" value="active" checked>
+                <label class="btn btn-outline-success" for="stand-filter-active">{{ 'Active'|trans }}</label>
+
+                <input type="checkbox" class="btn-check" id="stand-filter-technical" value="technical" checked>
+                <label class="btn btn-outline-warning" for="stand-filter-technical">{{ 'Technical'|trans }}</label>
+
+                <input type="checkbox" class="btn-check" id="stand-filter-hidden" value="hidden" checked>
+                <label class="btn btn-outline-info" for="stand-filter-hidden">{{ 'Hidden (testing)'|trans }}</label>
+
+                <input type="checkbox" class="btn-check" id="stand-filter-inactive" value="inactive" checked>
+                <label class="btn btn-outline-secondary" for="stand-filter-inactive">{{ 'Inactive'|trans }}</label>
+            </div>
             <div class="row" id="standsconsole">
 
             </div>


### PR DESCRIPTION
## Summary

Quality-of-life follow-up to #317. Admin stand cards now have a colored border per status, and a button-group filter above the cards toggles each status.

## Changes

**`templates/admin/stands.html.twig`**
- Multi-select button group above `#standsconsole`, one toggle per status (Active / Technical / Hidden / Inactive). All four enabled by default.

**`public/js/admin.js`**
- New `STAND_STATUS_BORDER` map (`active` → `border-success`, `technical` → `border-warning`, `hidden` → `border-info`, `inactive` → `border-secondary`).
- New `applyStandStatusToCard(\$card, status)` helper — sets border class, toggles `opacity-50` for inactive, swaps badge icons. Shared between initial render and PATCH success.
- New `applyStandStatusFilter()` — reads checked filter values, toggles column visibility. Re-applied on filter change and after PATCH (a card whose status moved out of the visible set is hidden immediately).

No backend changes. Bootstrap utility classes only — no new CSS.

## Test plan

- [x] PHPUnit: 380/380, phpcs clean (no backend changes, sanity check).
- [ ] Manual:
  - Open /admin → Stands tab. Each card has a colored border matching its status.
  - Inactive stands appear greyed out (opacity-50).
  - Untick "Inactive" → those cards disappear; tick again → reappear.
  - Untick all → empty grid; tick one → only that status visible.
  - Edit a card's status: border color updates immediately, badge swaps, no refetch. If new status is currently filtered out, card disappears.