### PR TITLE
feat(admin): highlight card-header background by status

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -240,21 +240,22 @@ function last(bikeNumber) {
     });
 }
 
-const STAND_STATUS_BORDER = {
-    active: 'border-success',
-    technical: 'border-warning',
-    hidden: 'border-info',
-    inactive: 'border-secondary',
+const STAND_STATUS_HEADER = {
+    active: 'bg-success text-white',
+    technical: 'bg-warning text-dark',
+    hidden: 'bg-info text-white',
+    inactive: 'bg-secondary text-white',
 };
-const STAND_STATUS_BORDER_CLASSES = Object.values(STAND_STATUS_BORDER).join(' ');
+const STAND_STATUS_HEADER_CLASSES = Object.values(STAND_STATUS_HEADER).join(' ');
 const STAND_STATUS_DIMMED_SELECTOR = '.card-header, .stand-description';
 const STAND_STATUS_FILTER_STORAGE_KEY = 'admin.stands.statusFilter';
 
 function applyStandStatusToCard($card, status) {
-    $card.removeClass(STAND_STATUS_BORDER_CLASSES);
+    const $header = $card.find('.card-header');
+    $header.removeClass(STAND_STATUS_HEADER_CLASSES);
     $card.find(STAND_STATUS_DIMMED_SELECTOR).removeClass('opacity-50');
-    if (STAND_STATUS_BORDER[status]) {
-        $card.addClass(STAND_STATUS_BORDER[status]);
+    if (STAND_STATUS_HEADER[status]) {
+        $header.addClass(STAND_STATUS_HEADER[status]);
     }
     if (status === 'inactive') {
         $card.find(STAND_STATUS_DIMMED_SELECTOR).addClass('opacity-50');


### PR DESCRIPTION
## Summary

Follow-up to #318. The border-color tweak from that PR was easy to miss — moving the color to the card header background makes the status unmistakable at a glance.

This commit was prepared as part of #318 but pushed after that PR was already squash-merged, so it landed in nobody's main. Re-shipping standalone.

## Changes

- `public/js/admin.js`: replace `border-*` classes on the outer card with `bg-* text-*` classes on `.card-header`:
  - active → `bg-success text-white`
  - technical → `bg-warning text-dark`
  - hidden → `bg-info text-white`
  - inactive → `bg-secondary text-white` (still combined with `opacity-50` on header + description)

Bootstrap 4.5 utility classes only — no new CSS, no markup changes.

## Test plan

- [ ] /admin → Stands tab → card headers are now colored:
  - active stands: green header
  - technical: yellow header
  - hidden: cyan header
  - inactive: grey + dimmed (opacity 0.5)
- [ ] Edit a stand's status and save → header color updates without page reload.
- [ ] Filter buttons + localStorage persistence keep working unchanged.