### PR TITLE
feat(stands): virtual status for off-city events

### DIFF
--- a/MIGRATION.MD
+++ b/MIGRATION.MD
@@ -30,4 +30,7 @@ ALTER TABLE `stands`
     ADD COLUMN `status` ENUM('active','technical','hidden','inactive') NOT NULL DEFAULT 'active' AFTER `serviceTag`;
 UPDATE `stands` SET `status` = 'technical' WHERE `serviceTag` <> 0;
 ALTER TABLE `stands` DROP COLUMN `serviceTag`;
+
+ALTER TABLE `stands`
+    MODIFY COLUMN `status` ENUM('active','technical','hidden','inactive','virtual') NOT NULL DEFAULT 'active';
 ```

--- a/docker-data/mysql/create-database.sql
+++ b/docker-data/mysql/create-database.sql
@@ -153,7 +153,7 @@ CREATE TABLE `stands` (
   `standName` varchar(50) NOT NULL,
   `standDescription` varchar(255),
   `standPhoto` varchar(255),
-  `status` ENUM('active','technical','hidden','inactive') NOT NULL DEFAULT 'active',
+  `status` ENUM('active','technical','hidden','inactive','virtual') NOT NULL DEFAULT 'active',
   `placeName` varchar(50) NOT NULL,
   `longitude` double(20,17),
   `latitude` double(20,17),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,7 +133,7 @@ paths:
               properties:
                 status:
                   type: string
-                  enum: [active, technical, hidden, inactive]
+                  enum: [active, technical, hidden, inactive, virtual]
       responses:
         "200":
           $ref: "#/components/responses/Success"

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -245,8 +245,16 @@ const STAND_STATUS_HEADER = {
     technical: 'bg-warning text-dark',
     hidden: 'bg-info text-white',
     inactive: 'bg-secondary text-white',
+    virtual: 'bg-primary text-white',
 };
 const STAND_STATUS_HEADER_CLASSES = Object.values(STAND_STATUS_HEADER).join(' ');
+const STAND_STATUS_BADGE = {
+    technical: '.service-stand',
+    hidden: '.hidden-stand',
+    inactive: '.removed-stand',
+    virtual: '.virtual-stand',
+};
+const STAND_STATUS_BADGE_SELECTOR = Object.values(STAND_STATUS_BADGE).join(', ');
 const STAND_STATUS_DIMMED_SELECTOR = '.card-header, .stand-description';
 const STAND_STATUS_FILTER_STORAGE_KEY = 'admin.stands.statusFilter';
 
@@ -261,18 +269,14 @@ function applyStandStatusToCard($card, status) {
         $card.find(STAND_STATUS_DIMMED_SELECTOR).addClass('opacity-50');
     }
 
-    $card.find('.service-stand, .hidden-stand, .removed-stand').addClass('d-none');
-    if (status === 'technical') {
-        $card.find('.service-stand').removeClass('d-none');
-    } else if (status === 'hidden') {
-        $card.find('.hidden-stand').removeClass('d-none');
-    } else if (status === 'inactive') {
-        $card.find('.removed-stand').removeClass('d-none');
+    $card.find(STAND_STATUS_BADGE_SELECTOR).addClass('d-none');
+    if (STAND_STATUS_BADGE[status]) {
+        $card.find(STAND_STATUS_BADGE[status]).removeClass('d-none');
     }
 }
 
 function applyStandStatusFilter() {
-    const enabled = $('.stand-status-filter .btn-check:checked')
+    const enabled = $('.stand-status-filter input[type="checkbox"]:checked')
         .map(function () { return this.value; })
         .get();
     $('#standsconsole > .stand-col').each(function () {
@@ -291,19 +295,21 @@ function loadStandStatusFilter() {
         return;
     }
     if (!Array.isArray(enabled)) return;
-    $('.stand-status-filter .btn-check').each(function () {
-        $(this).prop('checked', enabled.includes(this.value));
+    $('.stand-status-filter input[type="checkbox"]').each(function () {
+        const isChecked = enabled.includes(this.value);
+        $(this).prop('checked', isChecked);
+        $(this).closest('label').toggleClass('active', isChecked);
     });
 }
 
 function saveStandStatusFilter() {
-    const enabled = $('.stand-status-filter .btn-check:checked')
+    const enabled = $('.stand-status-filter input[type="checkbox"]:checked')
         .map(function () { return this.value; })
         .get();
     localStorage.setItem(STAND_STATUS_FILTER_STORAGE_KEY, JSON.stringify(enabled));
 }
 
-$(document).on('change', '.stand-status-filter .btn-check', function () {
+$(document).on('change', '.stand-status-filter input[type="checkbox"]', function () {
     saveStandStatusFilter();
     applyStandStatusFilter();
 });

--- a/src/Controller/QrCodeGeneratorController.php
+++ b/src/Controller/QrCodeGeneratorController.php
@@ -64,7 +64,7 @@ class QrCodeGeneratorController extends AbstractController
 
         $stands = $standRepository->findAll();
         foreach ($stands as $stand) {
-            if (StandStatus::from($stand["status"]) !== StandStatus::ACTIVE) {
+            if (!StandStatus::from($stand["status"])->isRentablePublic()) {
                 continue;
             }
 

--- a/src/Enum/StandStatus.php
+++ b/src/Enum/StandStatus.php
@@ -10,9 +10,10 @@ enum StandStatus: string
     case TECHNICAL = 'technical';
     case HIDDEN = 'hidden';
     case INACTIVE = 'inactive';
+    case VIRTUAL = 'virtual';
 
     public function isRentablePublic(): bool
     {
-        return $this === self::ACTIVE;
+        return $this === self::ACTIVE || $this === self::VIRTUAL;
     }
 }

--- a/src/Repository/BikeRepository.php
+++ b/src/Repository/BikeRepository.php
@@ -297,7 +297,7 @@ class BikeRepository
                 GROUP BY bikeNum
             ) AS movement ON movement.bikeNum = bikes.bikeNum
             WHERE bikes.currentStand IS NOT NULL
-                AND stands.status IN (:statusActive, :statusHidden)
+                AND stands.status IN (:statusActive, :statusHidden, :statusVirtual)
                 AND movement.lastMoveTime <= :thresholdTime
             ORDER BY movement.lastMoveTime DESC, bikes.bikeNum ASC",
             [
@@ -309,6 +309,7 @@ class BikeRepository
                 'thresholdTime' => $thresholdTime->format('Y-m-d H:i:s'),
                 'statusActive' => StandStatus::ACTIVE->value,
                 'statusHidden' => StandStatus::HIDDEN->value,
+                'statusVirtual' => StandStatus::VIRTUAL->value,
             ]
         )->fetchAllAssoc();
 

--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -1,18 +1,19 @@
+{% set standStatuses = [
+    {value: 'active', color: 'success', label: 'Active'},
+    {value: 'technical', color: 'warning', label: 'Technical'},
+    {value: 'hidden', color: 'info', label: 'Hidden (testing)'},
+    {value: 'inactive', color: 'secondary', label: 'Inactive'},
+    {value: 'virtual', color: 'primary', label: 'Virtual'},
+] %}
 {% block stands %}
     <div class="row">
         <div class="col-lg-12 mt-3">
-            <div class="btn-group btn-group-sm mb-3 stand-status-filter" role="group">
-                <input type="checkbox" class="btn-check" id="stand-filter-active" value="active" checked>
-                <label class="btn btn-outline-success" for="stand-filter-active">{{ 'Active'|trans }}</label>
-
-                <input type="checkbox" class="btn-check" id="stand-filter-technical" value="technical" checked>
-                <label class="btn btn-outline-warning" for="stand-filter-technical">{{ 'Technical'|trans }}</label>
-
-                <input type="checkbox" class="btn-check" id="stand-filter-hidden" value="hidden" checked>
-                <label class="btn btn-outline-info" for="stand-filter-hidden">{{ 'Hidden (testing)'|trans }}</label>
-
-                <input type="checkbox" class="btn-check" id="stand-filter-inactive" value="inactive" checked>
-                <label class="btn btn-outline-secondary" for="stand-filter-inactive">{{ 'Inactive'|trans }}</label>
+            <div class="btn-group btn-group-sm btn-group-toggle mb-3 stand-status-filter" data-toggle="buttons">
+                {% for status in standStatuses %}
+                    <label class="btn btn-outline-{{ status.color }} active">
+                        <input type="checkbox" autocomplete="off" value="{{ status.value }}" checked> {{ status.label|trans }}
+                    </label>
+                {% endfor %}
             </div>
             <div class="row" id="standsconsole">
 
@@ -25,6 +26,7 @@
                         <i class="fas fa-exclamation-triangle d-none service-stand"></i>
                         <i class="fas fa-eye-slash d-none hidden-stand"></i>
                         <i class="fas fa-ban d-none removed-stand"></i>
+                        <i class="fas fa-globe d-none virtual-stand"></i>
                     </div>
                     <div class="card-body">
                         <div class="mb-3">
@@ -38,11 +40,10 @@
                         <div class="mt-3">
                             <label class="form-label small mb-1">{{ 'Status'|trans }}</label>
                             <div class="input-group input-group-sm">
-                                <select class="stand-status form-select form-select-sm">
-                                    <option value="active">{{ 'Active'|trans }}</option>
-                                    <option value="technical">{{ 'Technical'|trans }}</option>
-                                    <option value="hidden">{{ 'Hidden (testing)'|trans }}</option>
-                                    <option value="inactive">{{ 'Inactive'|trans }}</option>
+                                <select class="stand-status form-control form-control-sm">
+                                    {% for status in standStatuses %}
+                                        <option value="{{ status.value }}">{{ status.label|trans }}</option>
+                                    {% endfor %}
                                 </select>
                                 <button type="button" class="btn btn-primary stand-status-save">
                                     {{ 'Save'|trans }}

--- a/tests/Application/Controller/Api/Stand/StandMarkersTest.php
+++ b/tests/Application/Controller/Api/Stand/StandMarkersTest.php
@@ -47,12 +47,13 @@ class StandMarkersTest extends BikeSharingWebTestCase
             $this->assertContains(
                 $marker['status'],
                 ['active', 'technical'],
-                'Regular user should not see hidden or inactive stands'
+                'Regular user should not see hidden, inactive or virtual stands'
             );
             $standNames[] = $marker['standName'];
         }
         $this->assertNotContains('HIDDEN_STAND', $standNames);
         $this->assertNotContains('INACTIVE_STAND', $standNames);
+        $this->assertNotContains('VIRTUAL_STAND', $standNames);
     }
 
     public function testMarkersByAdminIncludeHiddenButNotInactive(): void
@@ -74,6 +75,7 @@ class StandMarkersTest extends BikeSharingWebTestCase
         $this->assertArrayHasKey('HIDDEN_STAND', $byName, 'Admin should see hidden stand');
         $this->assertSame('hidden', $byName['HIDDEN_STAND']['status']);
         $this->assertArrayNotHasKey('INACTIVE_STAND', $byName, 'Admin should not see inactive stand');
+        $this->assertArrayNotHasKey('VIRTUAL_STAND', $byName, 'Admin map should not include virtual stands either');
     }
 
     public function testMarkersByToken(): void

--- a/tests/Application/Controller/Api/Stand/StandUpdateStatusTest.php
+++ b/tests/Application/Controller/Api/Stand/StandUpdateStatusTest.php
@@ -75,7 +75,7 @@ class StandUpdateStatusTest extends BikeSharingWebTestCase
             ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
         $this->client->loginUser($admin);
 
-        foreach (['technical', 'hidden', 'inactive', 'active'] as $status) {
+        foreach (['technical', 'hidden', 'inactive', 'virtual', 'active'] as $status) {
             $this->client->request(
                 Request::METHOD_PATCH,
                 '/api/v1/admin/stands/' . self::STAND_ID,

--- a/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
+++ b/tests/Integration/Command/InactiveStandBikesCheckCommandTest.php
@@ -24,10 +24,12 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
     private const BIKE_INACTIVE_LONG = 22;
     private const BIKE_ON_SERVICE_STAND = 23;
     private const BIKE_ON_HIDDEN_STAND = 24;
+    private const BIKE_ON_VIRTUAL_STAND = 25;
     private const STAND1_NAME = 'STAND1';
     private const STAND2_NAME = 'STAND2';
     private const SERVICE_STAND_NAME = 'SERVICE_STAND';
     private const HIDDEN_STAND_NAME = 'HIDDEN_STAND';
+    private const VIRTUAL_STAND_NAME = 'VIRTUAL_STAND';
 
     private int $adminUserId;
 
@@ -43,6 +45,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
         $this->simulateBikeActivity(self::BIKE_INACTIVE_LONG, self::STAND2_NAME, '2030-01-15 10:00:00');
         $this->simulateBikeActivity(self::BIKE_ON_SERVICE_STAND, self::SERVICE_STAND_NAME, '2030-01-20 10:00:00');
         $this->simulateBikeActivity(self::BIKE_ON_HIDDEN_STAND, self::HIDDEN_STAND_NAME, '2030-01-25 10:00:00');
+        $this->simulateBikeActivity(self::BIKE_ON_VIRTUAL_STAND, self::VIRTUAL_STAND_NAME, '2030-01-30 10:00:00');
         static::mockTime('2030-02-15 12:00:00');
     }
 
@@ -80,6 +83,11 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
             self::BIKE_ON_HIDDEN_STAND . ' | ' . self::HIDDEN_STAND_NAME,
             $message,
             'Bikes on hidden stands should be reported'
+        );
+        $this->assertStringContainsString(
+            self::BIKE_ON_VIRTUAL_STAND . ' | ' . self::VIRTUAL_STAND_NAME,
+            $message,
+            'Bikes on virtual stands should be reported'
         );
         $this->assertStringNotContainsString('- ' . self::BIKE_ON_SERVICE_STAND . ' |', $message);
 
@@ -126,6 +134,7 @@ class InactiveStandBikesCheckCommandTest extends BikeSharingKernelTestCase
             self::BIKE_INACTIVE_LONG,
             self::BIKE_ON_SERVICE_STAND,
             self::BIKE_ON_HIDDEN_STAND,
+            self::BIKE_ON_VIRTUAL_STAND,
         ];
         foreach ($bikes as $bikeNumber) {
             $rentSystem->returnBike($this->adminUserId, $bikeNumber, self::SERVICE_STAND_NAME, '', true);

--- a/tests/Integration/Rent/RentSystemTest.php
+++ b/tests/Integration/Rent/RentSystemTest.php
@@ -446,4 +446,34 @@ class RentSystemTest extends BikeSharingKernelTestCase
             true
         );
     }
+
+    public function testAnyoneCanRentBikeFromVirtualStand(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+        $rentSystemFactory = $container->get(RentSystemFactory::class);
+        $userRepository = $container->get(UserRepository::class);
+
+        $admin = $userRepository->findItemByPhoneNumber(self::ADMIN_PHONE_NUMBER);
+        $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
+
+        $rentSystem = $rentSystemFactory->getRentSystem(RentSystemType::WEB);
+        $rentSystem->returnBike($admin['userId'], self::BIKE_NUMBER, 'VIRTUAL_STAND', '', true);
+
+        $userResponse = $rentSystem->rentBike($user['userId'], self::BIKE_NUMBER);
+        $this->assertSame('bike.rent.success', $userResponse->getCode());
+
+        $rentSystem->returnBike($user['userId'], self::BIKE_NUMBER, 'VIRTUAL_STAND', '', true);
+
+        $adminResponse = $rentSystem->rentBike($admin['userId'], self::BIKE_NUMBER);
+        $this->assertSame('bike.rent.success', $adminResponse->getCode());
+
+        $rentSystem->returnBike(
+            $admin['userId'],
+            self::BIKE_NUMBER,
+            self::STAND_NAME,
+            '',
+            true
+        );
+    }
 }

--- a/tests/Unit/App/Api/Compat/AddServiceTagFromStatusTransformTest.php
+++ b/tests/Unit/App/Api/Compat/AddServiceTagFromStatusTransformTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Unit\App\Api\Compat;
 
 use BikeShare\App\Api\Compat\AddServiceTagFromStatusTransform;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class AddServiceTagFromStatusTransformTest extends TestCase
@@ -30,30 +31,24 @@ class AddServiceTagFromStatusTransformTest extends TestCase
         $this->assertContains('api_v1_admin_stand_item', $routes);
     }
 
-    public function testActiveStatusMapsToZeroServiceTag(): void
+    #[DataProvider('statusToServiceTagProvider')]
+    public function testStatusMapsToServiceTag(string $status, int $expectedServiceTag): void
     {
-        $data = [
-            ['standId' => 1, 'standName' => 'STAND1', 'status' => 'active'],
-        ];
+        $data = [['standId' => 1, 'status' => $status]];
 
         $result = $this->transform->transform($data);
 
-        $this->assertSame(0, $result[0]['serviceTag']);
-        $this->assertSame('active', $result[0]['status']);
+        $this->assertSame($expectedServiceTag, $result[0]['serviceTag']);
+        $this->assertSame($status, $result[0]['status']);
     }
 
-    public function testTechnicalStatusMapsToOne(): void
+    public static function statusToServiceTagProvider(): iterable
     {
-        $data = [['standId' => 6, 'status' => 'technical']];
-        $result = $this->transform->transform($data);
-        $this->assertSame(1, $result[0]['serviceTag']);
-    }
-
-    public function testHiddenStatusMapsToOne(): void
-    {
-        $data = [['standId' => 7, 'status' => 'hidden']];
-        $result = $this->transform->transform($data);
-        $this->assertSame(1, $result[0]['serviceTag']);
+        yield 'active' => ['active', 0];
+        yield 'technical' => ['technical', 1];
+        yield 'hidden' => ['hidden', 1];
+        yield 'inactive' => ['inactive', 0];
+        yield 'virtual' => ['virtual', 0];
     }
 
     public function testSingleObjectIsTransformed(): void

--- a/tests/fixtures/stands.yaml
+++ b/tests/fixtures/stands.yaml
@@ -33,3 +33,9 @@ stdClass:
     standName: 'INACTIVE_STAND'
     standDescription: '<streetName()>'
     status: 'inactive'
+
+  stand_virtual (extends defaultStand):
+    standId: '9'
+    standName: 'VIRTUAL_STAND'
+    standDescription: '<streetName()>'
+    status: 'virtual'


### PR DESCRIPTION
## Summary

Fifth `StandStatus` value: **virtual** — for stands tied to events or promo activities run outside the city, without a fixed geographic location.

Stacked on **#319** (header-bg-color cleanup); merge that one first or this PR will gain the bg-color change automatically once #319 lands.

## Semantics

| Aspect | Behavior |
|---|---|
| Map visibility | Never (no coords, server filters virtual out of `/stands/markers` for all roles) |
| Public rent | Allowed (`isRentablePublic` = true) — that's the point |
| QR codes | Yes (printed for handout at events) |
| Inactive-bikes report | Yes (bikes shouldn't stay parked after the event ends) |
| FREE-stands SMS | No (off-city, not relevant) |

## Changes

**Enum & data**
- `src/Enum/StandStatus.php`: added `case VIRTUAL = 'virtual'`; `isRentablePublic` now ACTIVE || VIRTUAL.
- `docker-data/mysql/create-database.sql`: ENUM extended.
- `MIGRATION.MD`: `ALTER TABLE stands MODIFY COLUMN status ENUM(...,'virtual') ...` for prod.

**Server**
- `BikeRepository::findInactiveBikes`: `IN (active, hidden, virtual)`.
- `QrCodeGeneratorController`: replaced `=== ACTIVE` with `!isRentablePublic()`; ACTIVE+VIRTUAL now both get QR codes.
- No changes to `markers()` / `findAllExtended` — default visible-set is still `[ACTIVE, TECHNICAL]` plus `HIDDEN` for admin; `VIRTUAL` stays out by design.

**Admin UI**
- New filter checkbox + label (`btn-outline-primary`).
- New `<option value="virtual">` in the status select.
- New badge: `<i class="fa-globe">` with `.virtual-stand` class.
- `STAND_STATUS_HEADER` JS map: `virtual: 'bg-primary text-white'` (blue header).
- `applyStandStatusToCard`: toggles the new badge.

**Drive-by fix**
- Status select was `form-select form-select-sm` (Bootstrap 5 classes — unstyled in BS 4.5.2). Switched to `form-control form-control-sm` matching the rest of the admin templates.

**OpenAPI**
- `enum: [active, technical, hidden, inactive, virtual]`.

## Test plan

- [x] PHPUnit: 381/381 passing in Docker, including:
  - `StandMarkersTest::testMarkersByUser` — VIRTUAL_STAND not in markers.
  - `StandMarkersTest::testMarkersByAdminIncludeHiddenButNotInactive` — VIRTUAL_STAND not in admin map either.
  - `StandUpdateStatusTest::testUpdateStatusAcceptsAllValidValues` — `virtual` accepted.
  - `RentSystemTest::testAnyoneCanRentBikeFromVirtualStand` — both user and admin can rent.
  - `InactiveStandBikesCheckCommandTest` — bike on VIRTUAL_STAND appears in the report (vs. SERVICE_STAND which is excluded).
- [x] phpcs clean.
- [ ] Manual: change a stand's status to `virtual` via admin → header turns blue, globe icon appears, virtual filter toggles it off correctly.
- [ ] Manual: as regular user open `/` → virtual stand absent from map. Same as admin.
- [ ] Manual: admin generates QR codes → virtual stands included.