### PR TITLE
feat(admin): show status icons in filter buttons

### DIFF
--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -1,9 +1,9 @@
 {% set standStatuses = [
-    {value: 'active', color: 'success', label: 'Active'},
-    {value: 'technical', color: 'warning', label: 'Technical'},
-    {value: 'hidden', color: 'info', label: 'Hidden (testing)'},
-    {value: 'inactive', color: 'secondary', label: 'Inactive'},
-    {value: 'virtual', color: 'primary', label: 'Virtual'},
+    {value: 'active', color: 'success', label: 'Active', icon: null, badgeClass: null},
+    {value: 'technical', color: 'warning', label: 'Technical', icon: 'fa-exclamation-triangle', badgeClass: 'service-stand'},
+    {value: 'hidden', color: 'info', label: 'Hidden (testing)', icon: 'fa-eye-slash', badgeClass: 'hidden-stand'},
+    {value: 'inactive', color: 'secondary', label: 'Inactive', icon: 'fa-ban', badgeClass: 'removed-stand'},
+    {value: 'virtual', color: 'primary', label: 'Virtual', icon: 'fa-globe', badgeClass: 'virtual-stand'},
 ] %}
 {% block stands %}
     <div class="row">
@@ -11,7 +11,9 @@
             <div class="btn-group btn-group-sm btn-group-toggle mb-3 stand-status-filter" data-toggle="buttons">
                 {% for status in standStatuses %}
                     <label class="btn btn-outline-{{ status.color }} active">
-                        <input type="checkbox" autocomplete="off" value="{{ status.value }}" checked> {{ status.label|trans }}
+                        <input type="checkbox" autocomplete="off" value="{{ status.value }}" checked>
+                        {% if status.icon %}<i class="fas {{ status.icon }}"></i>{% endif %}
+                        {{ status.label|trans }}
                     </label>
                 {% endfor %}
             </div>
@@ -23,10 +25,9 @@
                 <div class="card stand-card border" data-stand-id="">
                     <div class="card-header">
                         <span class="stand-name"></span>
-                        <i class="fas fa-exclamation-triangle d-none service-stand"></i>
-                        <i class="fas fa-eye-slash d-none hidden-stand"></i>
-                        <i class="fas fa-ban d-none removed-stand"></i>
-                        <i class="fas fa-globe d-none virtual-stand"></i>
+                        {% for status in standStatuses if status.badgeClass %}
+                            <i class="fas {{ status.icon }} d-none {{ status.badgeClass }}"></i>
+                        {% endfor %}
                     </div>
                     <div class="card-body">
                         <div class="mb-3">


### PR DESCRIPTION
## Summary

Quality-of-life follow-up to #320. The status filter buttons now show the same FontAwesome icon used as the card-header badge for that status, so admins can match a filtered card visually without reading the label.

| Status | Filter button | Card header badge |
|---|---|---|
| Active | text only | (no badge) |
| Technical | ⚠ + label | `fa-exclamation-triangle` |
| Hidden (testing) | 🚫 + label | `fa-eye-slash` |
| Inactive | ⛔ + label | `fa-ban` |
| Virtual | 🌐 + label | `fa-globe` |

## Changes

`templates/admin/stands.html.twig`:
- Extended the `standStatuses` Twig array with `icon` (FA class) and `badgeClass` (CSS class for JS toggle) fields.
- Filter button loop conditionally renders `<i class="fas {{ status.icon }}">` when icon is set.
- Card-header badges (4 hardcoded `<i>` elements) replaced with `{% for ... if status.badgeClass %}` loop driven by the same array.

Single source of truth — adding a 6th status in the future means one new entry in the array, no separate updates to filter UI, badge rendering, or JS class names.

No JS / no schema / no test changes — JS still references the existing badge CSS classes (`.service-stand` / `.hidden-stand` / `.removed-stand` / `.virtual-stand`).

## Test plan

- [x] PHPUnit: 383/383, phpcs clean (no functional change to verify in unit tests).
- [ ] Manual: `/admin` → Stands tab → filter buttons render with icons matching the card-header badges.
- [ ] Manual: Toggle a filter button (Technical etc.) → cards filter correctly; the active/inactive visual state of the toggle button is unchanged (Bootstrap 4 `data-toggle="buttons"` still drives it).