### PR TITLE
fix(admin): replace deprecated for...if Twig syntax with |filter

### DIFF
--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -25,7 +25,7 @@
                 <div class="card stand-card border" data-stand-id="">
                     <div class="card-header">
                         <span class="stand-name"></span>
-                        {% for status in standStatuses if status.badgeClass %}
+                        {% for status in standStatuses|filter(s => s.badgeClass) %}
                             <i class="fas {{ status.icon }} d-none {{ status.badgeClass }}"></i>
                         {% endfor %}
                     </div>


### PR DESCRIPTION
## Summary

Hotfix for **PHP-SYMFONY-48** in Sentry. The card-header badge loop introduced in #321 used the `{% for ... if condition %}` shorthand, which Twig 3 removed (deprecated since 2.10). Production log:

> `Twig\Error\SyntaxError: Unexpected token "name" of value "if" ("end of statement block" expected) in admin/stands.html.twig at line 28.`

8 events in 5 minutes after #321 deployed.

## Fix

```diff
-                        {% for status in standStatuses if status.badgeClass %}
+                        {% for status in standStatuses|filter(s => s.badgeClass) %}
```

`|filter` with arrow function is the standard Twig 2.10+/3.x replacement for the same semantics.

`bin/console lint:twig templates/admin/stands.html.twig` → OK locally.

## Why local tests passed

The unit/integration suite never renders this admin template; the deprecated syntax compiled lazily only on a production page hit. Worth adding `bin/console lint:twig templates/` to CI as a follow-up.