### PR TITLE
fix(admin): proper Bootstrap 4 styling for stand status select

### DIFF
--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -41,14 +41,16 @@
                         <div class="mt-3">
                             <label class="form-label small mb-1">{{ 'Status'|trans }}</label>
                             <div class="input-group input-group-sm">
-                                <select class="stand-status form-control form-control-sm">
+                                <select class="stand-status custom-select custom-select-sm">
                                     {% for status in standStatuses %}
                                         <option value="{{ status.value }}">{{ status.label|trans }}</option>
                                     {% endfor %}
                                 </select>
-                                <button type="button" class="btn btn-primary stand-status-save">
-                                    {{ 'Save'|trans }}
-                                </button>
+                                <div class="input-group-append">
+                                    <button type="button" class="btn btn-primary stand-status-save">
+                                        {{ 'Save'|trans }}
+                                    </button>
+                                </div>
                             </div>
                             <p class="stand-status-feedback small mt-1 mb-0 d-none"></p>
                         </div>


### PR DESCRIPTION
## Summary

The original ask: make the status select next to the Save button on each admin stand card look properly styled. My earlier fix only swapped BS5 `form-select` → BS4 `form-control`, which compiles but is the wrong idiom for the styled dropdown look + input-group attachment.

## Diff

```diff
 <div class="input-group input-group-sm">
-    <select class="stand-status form-control form-control-sm">
+    <select class="stand-status custom-select custom-select-sm">
         {% for status in standStatuses %}
             <option value="{{ status.value }}">{{ status.label|trans }}</option>
         {% endfor %}
     </select>
-    <button type="button" class="btn btn-primary stand-status-save">
-        {{ 'Save'|trans }}
-    </button>
+    <div class="input-group-append">
+        <button type="button" class="btn btn-primary stand-status-save">
+            {{ 'Save'|trans }}
+        </button>
+    </div>
 </div>
```

Two BS 4.5-specific corrections:
- `custom-select custom-select-sm` is BS4's class for the styled dropdown with a custom arrow (equivalent to BS5's `form-select`).
- Input-group add-on buttons must sit inside `<div class="input-group-append">` for the borders / flex to merge with the select. Without it the button "floats" as a separate element.

## Test plan

- [ ] /admin → Stands tab → status dropdown next to Save button now looks like a single styled control with the button glued to the right edge, matching the rest of the admin UI.
- [x] `bin/console lint:twig` clean.
- [x] PHPUnit unaffected (template-only change, no functional logic).