### PR TITLE
feat(admin): notify admins when a new user is fully verified

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -36,7 +36,10 @@ return static function (ContainerConfigurator $container): void {
         ->public()
         ->autoconfigure()
         ->autowire()
-        ->bind('$isSmsSystemEnabled', expr("container.getEnv('SMS_CONNECTOR') ? true : false"))
+        ->bind(
+            '$isSmsSystemEnabled',
+            expr("container.getEnv('SMS_CONNECTOR') and container.getEnv('SMS_CONNECTOR') != 'disabled'")
+        )
         ->bind('$appName', env('APP_NAME'))
         ->bind('$systemRules', env('SYSTEM_RULES'))
         ->bind('$defaultLocale', '%kernel.default_locale%')

--- a/src/Controller/Api/V1/UsersController.php
+++ b/src/Controller/Api/V1/UsersController.php
@@ -6,11 +6,13 @@ namespace BikeShare\Controller\Api\V1;
 
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Enum\Action;
+use BikeShare\Event\UserVerificationCompletedEvent;
 use BikeShare\Repository\BikeRepository;
 use BikeShare\Repository\CityRepository;
 use BikeShare\Repository\HistoryRepository;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Sms\SmsSenderInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +24,7 @@ class UsersController extends AbstractController
         private readonly UserRepository $userRepository,
         private readonly HistoryRepository $historyRepository,
         private readonly SmsSenderInterface $smsSender,
+        private readonly EventDispatcherInterface $eventDispatcher,
         private readonly int $freeTimeMinutes = 30,
         private readonly bool $isSmsSystemEnabled = false,
     ) {
@@ -174,6 +177,10 @@ class UsersController extends AbstractController
 
         $this->userRepository->confirmUserNumber($user->getUserId());
         $this->historyRepository->addItem($user->getUserId(), 0, Action::PHONE_CONFIRMED, '');
+
+        $this->eventDispatcher->dispatch(
+            new UserVerificationCompletedEvent($user->getUserId())
+        );
 
         return $this->json(['message' => 'Phone number confirmed successfully.']);
     }

--- a/src/Controller/EmailConfirmController.php
+++ b/src/Controller/EmailConfirmController.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace BikeShare\Controller;
 
 use BikeShare\Enum\Action;
+use BikeShare\Event\UserVerificationCompletedEvent;
 use BikeShare\Repository\HistoryRepository;
 use BikeShare\Repository\RegistrationRepository;
 use BikeShare\Repository\UserRepository;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -20,6 +22,7 @@ class EmailConfirmController extends AbstractController
         UserRepository $userRepository,
         HistoryRepository $historyRepository,
         TranslatorInterface $translator,
+        EventDispatcherInterface $eventDispatcher,
         int $userBikeLimitAfterRegistration = 0
     ): Response {
         if (!empty($key)) {
@@ -39,6 +42,10 @@ class EmailConfirmController extends AbstractController
                     0,
                     Action::EMAIL_CONFIRMED,
                     ''
+                );
+
+                $eventDispatcher->dispatch(
+                    new UserVerificationCompletedEvent((int)$registration['userId'])
                 );
 
                 $this->addFlash(

--- a/src/Controller/PhoneConfirmController.php
+++ b/src/Controller/PhoneConfirmController.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace BikeShare\Controller;
 
 use BikeShare\Enum\Action;
+use BikeShare\Event\UserVerificationCompletedEvent;
 use BikeShare\Repository\HistoryRepository;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Sms\SmsSenderInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,7 +27,8 @@ class PhoneConfirmController extends AbstractController
         Request $request,
         SessionInterface $session,
         TranslatorInterface $translator,
-        UserRepository $userRepository
+        UserRepository $userRepository,
+        EventDispatcherInterface $eventDispatcher
     ): Response {
         // Only logged users can verify their phone
         $user = $this->getUser();
@@ -93,6 +96,10 @@ class PhoneConfirmController extends AbstractController
                 if ($history) {
                     $userRepository->confirmUserNumber($user->getUserId());
                     $historyRepository->addItem($user->getUserId(), 0, Action::PHONE_CONFIRMED, '');
+
+                    $eventDispatcher->dispatch(
+                        new UserVerificationCompletedEvent($user->getUserId())
+                    );
 
                     $session->remove('phoneCheckCode');
                     $session->remove('phoneVerificationStep');

--- a/src/Event/UserVerificationCompletedEvent.php
+++ b/src/Event/UserVerificationCompletedEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Event;
+
+class UserVerificationCompletedEvent
+{
+    public function __construct(private readonly int $userId)
+    {
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+}

--- a/src/EventListener/NewUserAdminNotifierEventListener.php
+++ b/src/EventListener/NewUserAdminNotifierEventListener.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\EventListener;
+
+use BikeShare\Event\UserVerificationCompletedEvent;
+use BikeShare\Notifier\AdminNotifier;
+use BikeShare\Repository\RegistrationRepository;
+use BikeShare\Repository\UserRepository;
+use Symfony\Component\Translation\TranslatableMessage;
+
+class NewUserAdminNotifierEventListener
+{
+    public function __construct(
+        private readonly bool $isSmsSystemEnabled,
+        private readonly AdminNotifier $adminNotifier,
+        private readonly UserRepository $userRepository,
+        private readonly RegistrationRepository $registrationRepository,
+    ) {
+    }
+
+    public function __invoke(UserVerificationCompletedEvent $event): void
+    {
+        $userId = $event->getUserId();
+
+        $user = $this->userRepository->findItem($userId);
+        if ($user === null) {
+            return;
+        }
+
+        if ($this->registrationRepository->findItemByUserId($userId) !== null) {
+            return;
+        }
+
+        // When the SMS system is enabled, phone confirmation is required for full verification.
+        // When it's disabled, users have no way to confirm phone, so email-confirm alone is enough.
+        if ($this->isSmsSystemEnabled && (int)$user['isNumberConfirmed'] !== 1) {
+            return;
+        }
+
+        $this->adminNotifier->notify(
+            new TranslatableMessage(
+                'admin.notification.new_verified_user',
+                [
+                    'userName' => $user['userName'],
+                    'email' => $user['mail'],
+                    'phone' => $user['number'],
+                ]
+            ),
+            bySms: false,
+        );
+    }
+}

--- a/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
+++ b/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Flow;
+
+use BikeShare\Db\DbInterface;
+use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Repository\UserRepository;
+use BikeShare\Sms\DebugSmsSender;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatableMessage;
+
+class ApiPhoneConfirmAdminNotifyTest extends BikeSharingWebTestCase
+{
+    private const USER_ID = 10;
+    private const USER_PHONE_NUMBER = '421951555555';
+    private const USER_PASSWORD = 'password';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Mark phone as unconfirmed so we exercise the phone-confirm flow.
+        // Also reset the password — UserControllerTest::testChangePassword may have changed it
+        // depending on test discovery order.
+        $db = $this->client->getContainer()->get(DbInterface::class);
+        $db->query(
+            'UPDATE users SET isNumberConfirmed = 0, password = :password WHERE userId = :userId',
+            [
+                'userId' => self::USER_ID,
+                'password' => password_hash(self::USER_PASSWORD, PASSWORD_BCRYPT, ['cost' => 13]),
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore the fixture state so other tests aren't affected.
+        $db = $this->client->getContainer()->get(DbInterface::class);
+        $db->query(
+            'UPDATE users SET isNumberConfirmed = 1 WHERE userId = :userId',
+            ['userId' => self::USER_ID]
+        );
+        parent::tearDown();
+    }
+
+    public function testAdminNotifiedAfterApiPhoneConfirmVerify(): void
+    {
+        // 1. Get JWT access token.
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/auth/token',
+            [
+                'number' => self::USER_PHONE_NUMBER,
+                'password' => self::USER_PASSWORD,
+            ]
+        );
+        $this->assertResponseIsSuccessful();
+        $tokenPayload = $this->decodeApiResponseData();
+        $this->assertFalse($tokenPayload['phoneConfirmed'], 'Phone should be unconfirmed at this point');
+        $authHeader = ['HTTP_AUTHORIZATION' => 'Bearer ' . $tokenPayload['accessToken']];
+
+        // 2. Request SMS code via API.
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/request',
+            server: $authHeader
+        );
+        $this->assertResponseIsSuccessful();
+        $requestPayload = $this->decodeApiResponseData();
+        $this->assertArrayHasKey('checkCode', $requestPayload);
+        $checkCode = $requestPayload['checkCode'];
+
+        // 3. Pull the SMS code from DebugSmsSender.
+        $smsSender = $this->client->getContainer()->get(DebugSmsSender::class);
+        $sentMessages = $smsSender->getSentMessages();
+        $this->assertCount(1, $sentMessages, 'Expected one SMS with the verification code');
+        $smsMessage = $sentMessages[0]['message'];
+        $this->assertInstanceOf(TranslatableMessage::class, $smsMessage);
+        $smsCodeRaw = $smsMessage->getParameters()['smsCode'] ?? '';
+        $this->assertMatchesRegularExpression('/^[A-Z]{2} \d+$/', $smsCodeRaw);
+
+        // 4. Verify the SMS code via API — this dispatches UserVerificationCompletedEvent.
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/verify',
+            [
+                'code' => $smsCodeRaw,
+                'checkCode' => $checkCode,
+            ],
+            server: $authHeader
+        );
+        $this->assertResponseIsSuccessful();
+
+        // Capture admin emails BEFORE any subsequent request (DebugMailSender resets per request).
+        $emailsAfterVerify = static::getContainer()->get(MailSenderInterface::class)->getSentMessages();
+
+        $this->assertCount(1, $emailsAfterVerify, 'Expected exactly one admin notification email after API phone confirmation');
+
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $user = $userRepository->findItem(self::USER_ID);
+        $this->assertSame(1, (int)$user['isNumberConfirmed'], 'Phone should be confirmed after verify');
+
+        // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
+        $superAdmin = $userRepository->findItem(7);
+        $adminEmail = $emailsAfterVerify[0];
+        $this->assertSame($superAdmin['mail'], $adminEmail['recipient']);
+        $this->assertStringContainsString($user['mail'], $adminEmail['message']);
+        $this->assertStringContainsString($user['number'], $adminEmail['message']);
+    }
+}

--- a/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
+++ b/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
@@ -13,8 +13,8 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class ApiPhoneConfirmAdminNotifyTest extends BikeSharingWebTestCase
 {
-    private const USER_ID = 11;
     private const USER_PHONE_NUMBER = '421951666666';
+    private const SUPER_ADMIN_PHONE_NUMBER = '421951777777';
     private const USER_PASSWORD = 'password';
 
     public function testAdminNotifiedAfterApiPhoneConfirmVerify(): void
@@ -75,11 +75,10 @@ class ApiPhoneConfirmAdminNotifyTest extends BikeSharingWebTestCase
         );
 
         $userRepository = static::getContainer()->get(UserRepository::class);
-        $user = $userRepository->findItem(self::USER_ID);
+        $user = $userRepository->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
         $this->assertSame(1, (int)$user['isNumberConfirmed'], 'Phone should be confirmed after verify');
 
-        // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
-        $superAdmin = $userRepository->findItem(7);
+        $superAdmin = $userRepository->findItemByPhoneNumber(self::SUPER_ADMIN_PHONE_NUMBER);
         $adminEmail = $emailsAfterVerify[0];
         $this->assertSame($superAdmin['mail'], $adminEmail['recipient']);
         $this->assertStringContainsString($user['mail'], $adminEmail['message']);

--- a/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
+++ b/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
@@ -96,7 +96,11 @@ class ApiPhoneConfirmAdminNotifyTest extends BikeSharingWebTestCase
         // Capture admin emails BEFORE any subsequent request (DebugMailSender resets per request).
         $emailsAfterVerify = static::getContainer()->get(MailSenderInterface::class)->getSentMessages();
 
-        $this->assertCount(1, $emailsAfterVerify, 'Expected exactly one admin notification email after API phone confirmation');
+        $this->assertCount(
+            1,
+            $emailsAfterVerify,
+            'Expected exactly one admin notification email after API phone confirmation'
+        );
 
         $userRepository = static::getContainer()->get(UserRepository::class);
         $user = $userRepository->findItem(self::USER_ID);

--- a/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
+++ b/tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BikeShare\Test\Application\Flow;
 
-use BikeShare\Db\DbInterface;
 use BikeShare\Mail\MailSenderInterface;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Sms\DebugSmsSender;
@@ -14,36 +13,9 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class ApiPhoneConfirmAdminNotifyTest extends BikeSharingWebTestCase
 {
-    private const USER_ID = 10;
-    private const USER_PHONE_NUMBER = '421951555555';
+    private const USER_ID = 11;
+    private const USER_PHONE_NUMBER = '421951666666';
     private const USER_PASSWORD = 'password';
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-        // Mark phone as unconfirmed so we exercise the phone-confirm flow.
-        // Also reset the password — UserControllerTest::testChangePassword may have changed it
-        // depending on test discovery order.
-        $db = $this->client->getContainer()->get(DbInterface::class);
-        $db->query(
-            'UPDATE users SET isNumberConfirmed = 0, password = :password WHERE userId = :userId',
-            [
-                'userId' => self::USER_ID,
-                'password' => password_hash(self::USER_PASSWORD, PASSWORD_BCRYPT, ['cost' => 13]),
-            ]
-        );
-    }
-
-    protected function tearDown(): void
-    {
-        // Restore the fixture state so other tests aren't affected.
-        $db = $this->client->getContainer()->get(DbInterface::class);
-        $db->query(
-            'UPDATE users SET isNumberConfirmed = 1 WHERE userId = :userId',
-            ['userId' => self::USER_ID]
-        );
-        parent::tearDown();
-    }
 
     public function testAdminNotifiedAfterApiPhoneConfirmVerify(): void
     {

--- a/tests/Application/Flow/RegistrationFlowTest.php
+++ b/tests/Application/Flow/RegistrationFlowTest.php
@@ -116,7 +116,11 @@ class RegistrationFlowTest extends BikeSharingWebTestCase
         $this->assertSame(1, $user['isNumberConfirmed'], 'User phone number is not confirmed');
 
         // Admins were notified about the newly fully-verified user.
-        $this->assertCount(1, $emailsAfterPhoneConfirm, 'Expected one admin notification email after phone confirmation');
+        $this->assertCount(
+            1,
+            $emailsAfterPhoneConfirm,
+            'Expected one admin notification email after phone confirmation'
+        );
 
         // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
         $superAdmin = $userRepository->findItem(7);

--- a/tests/Application/Flow/RegistrationFlowTest.php
+++ b/tests/Application/Flow/RegistrationFlowTest.php
@@ -15,6 +15,8 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 class RegistrationFlowTest extends BikeSharingWebTestCase
 {
+    private const SUPER_ADMIN_PHONE_NUMBER = '421951777777';
+
     public function testFullRegistrationFlow(): void
     {
         $userEmail = 'test_' . time() . '@example.com';
@@ -122,8 +124,7 @@ class RegistrationFlowTest extends BikeSharingWebTestCase
             'Expected one admin notification email after phone confirmation'
         );
 
-        // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
-        $superAdmin = $userRepository->findItem(7);
+        $superAdmin = $userRepository->findItemByPhoneNumber(self::SUPER_ADMIN_PHONE_NUMBER);
         $adminEmail = $emailsAfterPhoneConfirm[0];
         $this->assertSame($superAdmin['mail'], $adminEmail['recipient']);
         $this->assertStringContainsString($userEmail, $adminEmail['message']);

--- a/tests/Application/Flow/RegistrationFlowTest.php
+++ b/tests/Application/Flow/RegistrationFlowTest.php
@@ -102,6 +102,11 @@ class RegistrationFlowTest extends BikeSharingWebTestCase
             'form[smscode]' => $smsCode,
         ]);
         $this->assertResponseRedirects();
+
+        // Re-fetch mail sender — kernel reboots between requests, replacing the DebugMailSender instance.
+        // Capture BEFORE followRedirect (next request resets the buffer).
+        $emailsAfterPhoneConfirm = static::getContainer()->get(MailSenderInterface::class)->getSentMessages();
+
         $this->client->followRedirect();
         $this->assertRouteSame('home');
 
@@ -109,5 +114,15 @@ class RegistrationFlowTest extends BikeSharingWebTestCase
         $user = $userRepository->findItemByEmail($userEmail);
         $this->assertNotNull($user);
         $this->assertSame(1, $user['isNumberConfirmed'], 'User phone number is not confirmed');
+
+        // Admins were notified about the newly fully-verified user.
+        $this->assertCount(1, $emailsAfterPhoneConfirm, 'Expected one admin notification email after phone confirmation');
+
+        // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
+        $superAdmin = $userRepository->findItem(7);
+        $adminEmail = $emailsAfterPhoneConfirm[0];
+        $this->assertSame($superAdmin['mail'], $adminEmail['recipient']);
+        $this->assertStringContainsString($userEmail, $adminEmail['message']);
+        $this->assertStringContainsString($phonePurifier->purify($userPhone), $adminEmail['message']);
     }
 }

--- a/tests/Application/Flow/SmsDisabledRegistrationFlowTest.php
+++ b/tests/Application/Flow/SmsDisabledRegistrationFlowTest.php
@@ -8,42 +8,29 @@ use BikeShare\Mail\MailSenderInterface;
 use BikeShare\Repository\RegistrationRepository;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
-use Monolog\Logger;
 use Symfony\Component\HttpFoundation\Request;
 
 class SmsDisabledRegistrationFlowTest extends BikeSharingWebTestCase
 {
     private const SUPER_ADMIN_PHONE_NUMBER = '421951777777';
 
-    private ?string $originalSmsConnector = null;
+    private string $originalSmsConnector;
 
     protected function setUp(): void
     {
-        $this->originalSmsConnector = $_SERVER['SMS_CONNECTOR'] ?? null;
-        $_SERVER['SMS_CONNECTOR'] = '';
-        $_ENV['SMS_CONNECTOR'] = '';
+        $this->originalSmsConnector = $_ENV['SMS_CONNECTOR'];
+        $_ENV['SMS_CONNECTOR'] = 'disabled';
         parent::setUp();
     }
 
     protected function tearDown(): void
     {
-        // Restore env BEFORE parent's log assertions — if parent throws, env still gets restored
-        // and won't leak SMS_CONNECTOR='' into the next test class.
-        if ($this->originalSmsConnector === null) {
-            unset($_SERVER['SMS_CONNECTOR'], $_ENV['SMS_CONNECTOR']);
-        } else {
-            $_SERVER['SMS_CONNECTOR'] = $this->originalSmsConnector;
-            $_ENV['SMS_CONNECTOR'] = $this->originalSmsConnector;
-        }
+        $_ENV['SMS_CONNECTOR'] = $this->originalSmsConnector;
         parent::tearDown();
     }
 
     public function testAdminNotifiedRightAfterEmailConfirmWhenSmsDisabled(): void
     {
-        // SmsConnectorFactory falls back to DisabledConnector when SMS_CONNECTOR is empty
-        // and logs an error. We tolerate it — the fallback is the project's own design.
-        $this->expectLog(Logger::ERROR, '/Error creating SMS connector/');
-
         $userEmail = 'test_sms_disabled_' . time() . '@example.com';
         $userPhone = '+421901' . rand(100000, 999999);
 

--- a/tests/Application/Flow/SmsDisabledRegistrationFlowTest.php
+++ b/tests/Application/Flow/SmsDisabledRegistrationFlowTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Flow;
+
+use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Repository\RegistrationRepository;
+use BikeShare\Repository\UserRepository;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Request;
+
+class SmsDisabledRegistrationFlowTest extends BikeSharingWebTestCase
+{
+    private ?string $originalSmsConnector = null;
+
+    protected function setUp(): void
+    {
+        $this->originalSmsConnector = $_SERVER['SMS_CONNECTOR'] ?? null;
+        $_SERVER['SMS_CONNECTOR'] = '';
+        $_ENV['SMS_CONNECTOR'] = '';
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore env BEFORE parent's log assertions — if parent throws, env still gets restored
+        // and won't leak SMS_CONNECTOR='' into the next test class.
+        if ($this->originalSmsConnector === null) {
+            unset($_SERVER['SMS_CONNECTOR'], $_ENV['SMS_CONNECTOR']);
+        } else {
+            $_SERVER['SMS_CONNECTOR'] = $this->originalSmsConnector;
+            $_ENV['SMS_CONNECTOR'] = $this->originalSmsConnector;
+        }
+        parent::tearDown();
+    }
+
+    public function testAdminNotifiedRightAfterEmailConfirmWhenSmsDisabled(): void
+    {
+        // SmsConnectorFactory falls back to DisabledConnector when SMS_CONNECTOR is empty
+        // and logs an error. We tolerate it — the fallback is the project's own design.
+        $this->expectLog(Logger::ERROR, '/Error creating SMS connector/');
+
+        $userEmail = 'test_sms_disabled_' . time() . '@example.com';
+        $userPhone = '+421901' . rand(100000, 999999);
+
+        $this->client->request(Request::METHOD_GET, '/register');
+        $this->assertResponseIsSuccessful();
+
+        $this->client->submitForm('register', [
+            'registration_form[fullname]' => 'Jane Doe',
+            'registration_form[city]' => 'Default City',
+            'registration_form[useremail]' => $userEmail,
+            'registration_form[password]' => 'password',
+            'registration_form[password2]' => 'password',
+            'registration_form[number]' => $userPhone,
+            'registration_form[agree]' => '1',
+        ]);
+        $this->assertResponseRedirects('/');
+
+        // After registration: only the email confirmation link.
+        $emailsAfterRegister = static::getContainer()->get(MailSenderInterface::class)->getSentMessages();
+        $this->assertCount(1, $emailsAfterRegister, 'Expected only the registration confirmation link');
+
+        // Extract confirmation link.
+        preg_match('/(\/user\/confirm\/email\/[a-z0-9]+)/', $emailsAfterRegister[0]['message'], $matches);
+        $confirmationLink = $matches[1] ?? null;
+        $this->assertNotNull($confirmationLink, 'Email confirmation link not found in registration email');
+
+        // Confirm email.
+        $this->client->request(Request::METHOD_GET, $confirmationLink);
+        $this->assertResponseRedirects('/');
+
+        // Capture emails BEFORE any next request (DebugMailSender resets between requests).
+        $emailsAfterEmailConfirm = static::getContainer()->get(MailSenderInterface::class)->getSentMessages();
+
+        // Email-confirm controller dispatches UserVerificationCompletedEvent;
+        // listener with isSmsSystemEnabled=false notifies admins immediately, no phone step required.
+        $this->assertCount(1, $emailsAfterEmailConfirm, 'Expected admin notification email after email confirmation');
+
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $registrationRepository = static::getContainer()->get(RegistrationRepository::class);
+
+        $user = $userRepository->findItemByEmail($userEmail);
+        $this->assertNotNull($user);
+        $this->assertSame(0, (int)$user['isNumberConfirmed'], 'Phone confirmation should NOT happen when SMS disabled');
+        $this->assertNull(
+            $registrationRepository->findItemByUserId($user['userId']),
+            'Registration row should be deleted after email confirmation'
+        );
+
+        // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
+        $superAdmin = $userRepository->findItem(7);
+        $adminEmail = $emailsAfterEmailConfirm[0];
+        $this->assertSame($superAdmin['mail'], $adminEmail['recipient']);
+        $this->assertStringContainsString($userEmail, $adminEmail['message']);
+    }
+}

--- a/tests/Application/Flow/SmsDisabledRegistrationFlowTest.php
+++ b/tests/Application/Flow/SmsDisabledRegistrationFlowTest.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SmsDisabledRegistrationFlowTest extends BikeSharingWebTestCase
 {
+    private const SUPER_ADMIN_PHONE_NUMBER = '421951777777';
+
     private ?string $originalSmsConnector = null;
 
     protected function setUp(): void
@@ -90,8 +92,7 @@ class SmsDisabledRegistrationFlowTest extends BikeSharingWebTestCase
             'Registration row should be deleted after email confirmation'
         );
 
-        // Fixture defines superAdmin (userId=7, privileges=7) — only user matching `privileges & 2 != 0`.
-        $superAdmin = $userRepository->findItem(7);
+        $superAdmin = $userRepository->findItemByPhoneNumber(self::SUPER_ADMIN_PHONE_NUMBER);
         $adminEmail = $emailsAfterEmailConfirm[0];
         $this->assertSame($superAdmin['mail'], $adminEmail['recipient']);
         $this->assertStringContainsString($userEmail, $adminEmail['message']);

--- a/tests/Unit/EventListener/NewUserAdminNotifierEventListenerTest.php
+++ b/tests/Unit/EventListener/NewUserAdminNotifierEventListenerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Unit\EventListener;
+
+use BikeShare\Event\UserVerificationCompletedEvent;
+use BikeShare\EventListener\NewUserAdminNotifierEventListener;
+use BikeShare\Notifier\AdminNotifier;
+use BikeShare\Repository\RegistrationRepository;
+use BikeShare\Repository\UserRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\TranslatableMessage;
+
+class NewUserAdminNotifierEventListenerTest extends TestCase
+{
+    private AdminNotifier&MockObject $adminNotifierMock;
+    private UserRepository&MockObject $userRepositoryMock;
+    private RegistrationRepository&MockObject $registrationRepositoryMock;
+
+    protected function setUp(): void
+    {
+        $this->adminNotifierMock = $this->createMock(AdminNotifier::class);
+        $this->userRepositoryMock = $this->createMock(UserRepository::class);
+        $this->registrationRepositoryMock = $this->createMock(RegistrationRepository::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->adminNotifierMock,
+            $this->userRepositoryMock,
+            $this->registrationRepositoryMock,
+        );
+    }
+
+    private function createListener(bool $isSmsSystemEnabled): NewUserAdminNotifierEventListener
+    {
+        return new NewUserAdminNotifierEventListener(
+            $isSmsSystemEnabled,
+            $this->adminNotifierMock,
+            $this->userRepositoryMock,
+            $this->registrationRepositoryMock,
+        );
+    }
+
+    public function testNotifiesAdminsWhenFullyVerified(): void
+    {
+        $userId = 42;
+
+        $this->userRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($userId)
+            ->willReturn([
+                'userId' => $userId,
+                'userName' => 'John Doe',
+                'mail' => 'john@example.com',
+                'number' => '421900111222',
+                'isNumberConfirmed' => 1,
+            ]);
+        $this->registrationRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByUserId')
+            ->with($userId)
+            ->willReturn(null);
+
+        $this->adminNotifierMock
+            ->expects($this->once())
+            ->method('notify')
+            ->with(
+                $this->callback(function (TranslatableMessage $msg): bool {
+                    $this->assertSame('admin.notification.new_verified_user', $msg->getMessage());
+                    $this->assertSame(
+                        [
+                            'userName' => 'John Doe',
+                            'email' => 'john@example.com',
+                            'phone' => '421900111222',
+                        ],
+                        $msg->getParameters()
+                    );
+                    return true;
+                }),
+                false
+            );
+
+        ($this->createListener(isSmsSystemEnabled: true))(new UserVerificationCompletedEvent($userId));
+    }
+
+    public function testDoesNothingWhenPhoneNotConfirmedAndSmsEnabled(): void
+    {
+        $userId = 42;
+
+        $this->userRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($userId)
+            ->willReturn([
+                'userId' => $userId,
+                'userName' => 'John Doe',
+                'mail' => 'john@example.com',
+                'number' => '421900111222',
+                'isNumberConfirmed' => 0,
+            ]);
+        $this->registrationRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByUserId')
+            ->with($userId)
+            ->willReturn(null);
+        $this->adminNotifierMock->expects($this->never())->method('notify');
+
+        ($this->createListener(isSmsSystemEnabled: true))(new UserVerificationCompletedEvent($userId));
+    }
+
+    public function testNotifiesWhenSmsDisabledEvenIfPhoneNotConfirmed(): void
+    {
+        $userId = 42;
+
+        $this->userRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($userId)
+            ->willReturn([
+                'userId' => $userId,
+                'userName' => 'John Doe',
+                'mail' => 'john@example.com',
+                'number' => '421900111222',
+                'isNumberConfirmed' => 0,
+            ]);
+        $this->registrationRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByUserId')
+            ->with($userId)
+            ->willReturn(null);
+
+        $this->adminNotifierMock
+            ->expects($this->once())
+            ->method('notify')
+            ->with($this->isInstanceOf(TranslatableMessage::class), false);
+
+        ($this->createListener(isSmsSystemEnabled: false))(new UserVerificationCompletedEvent($userId));
+    }
+
+    public function testDoesNothingWhenUserMissing(): void
+    {
+        $userId = 42;
+
+        $this->userRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($userId)
+            ->willReturn(null);
+        $this->registrationRepositoryMock->expects($this->never())->method('findItemByUserId');
+        $this->adminNotifierMock->expects($this->never())->method('notify');
+
+        ($this->createListener(isSmsSystemEnabled: true))(new UserVerificationCompletedEvent($userId));
+    }
+
+    public function testDoesNothingWhenEmailRegistrationStillPending(): void
+    {
+        $userId = 42;
+
+        $this->userRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($userId)
+            ->willReturn([
+                'userId' => $userId,
+                'userName' => 'John Doe',
+                'mail' => 'john@example.com',
+                'number' => '421900111222',
+                'isNumberConfirmed' => 1,
+            ]);
+        $this->registrationRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByUserId')
+            ->with($userId)
+            ->willReturn(['userId' => $userId, 'userKey' => 'pending']);
+        $this->adminNotifierMock->expects($this->never())->method('notify');
+
+        ($this->createListener(isSmsSystemEnabled: true))(new UserVerificationCompletedEvent($userId));
+    }
+
+    public function testDoesNothingWhenSmsDisabledAndEmailRegistrationStillPending(): void
+    {
+        $userId = 42;
+
+        $this->userRepositoryMock
+            ->expects($this->once())
+            ->method('findItem')
+            ->with($userId)
+            ->willReturn([
+                'userId' => $userId,
+                'userName' => 'John Doe',
+                'mail' => 'john@example.com',
+                'number' => '421900111222',
+                'isNumberConfirmed' => 0,
+            ]);
+        $this->registrationRepositoryMock
+            ->expects($this->once())
+            ->method('findItemByUserId')
+            ->with($userId)
+            ->willReturn(['userId' => $userId, 'userKey' => 'pending']);
+        $this->adminNotifierMock->expects($this->never())->method('notify');
+
+        ($this->createListener(isSmsSystemEnabled: false))(new UserVerificationCompletedEvent($userId));
+    }
+}

--- a/tests/fixtures/users.yaml
+++ b/tests/fixtures/users.yaml
@@ -55,3 +55,11 @@ stdClass:
     number: 421951555555
     userLimit: 0
     password: '<(password_hash("password", PASSWORD_BCRYPT, ["cost" => 13]))>'
+
+  userForApiPhoneConfirmTest (extends defaultUser):
+    userId: 11
+    privileges: 0
+    number: 421951666666
+    userLimit: 0
+    isNumberConfirmed: 0
+    password: '<(password_hash("password", PASSWORD_BCRYPT, ["cost" => 13]))>'

--- a/tests/fixtures/users.yaml
+++ b/tests/fixtures/users.yaml
@@ -35,6 +35,7 @@ stdClass:
   superAdmin (extends defaultUser):
     userId: 7
     privileges: 7
+    number: 421951777777
     userLimit: 7
 
   userForRegistrationTest (extends defaultUser):

--- a/translations/messages+intl-icu.cs.php
+++ b/translations/messages+intl-icu.cs.php
@@ -217,6 +217,10 @@ Kliknutím na následující odkaz potvrdíte svůj e-mail: {emailConfirmURL}',
     'user.error.phone_already_registered' => 'Uživatel s tímto telefonním číslem je již registrován.',
     'user.error.email_already_registered' => 'Uživatel s tímto e-mailem je již registrován.',
     'admin.notification.subject' => '{appName} oznámení',
+    'admin.notification.new_verified_user' => 'Nový uživatel právě potvrdil e-mail a telefon. Prosím, kontaktujte ho na uvítací / onboarding hovor.
+Jméno: {userName}
+E-mail: {email}
+Telefon: {phone}',
     'admin.notification.sms_problem' => 'Problém s SMS: {number}-{sms}',
     'admin.notification.sms_processed' => '{userName}: {message}',
     'admin.notification.duplicate_sms' => 'Problém s SMS: {uuid}',

--- a/translations/messages+intl-icu.de.php
+++ b/translations/messages+intl-icu.de.php
@@ -220,6 +220,10 @@ Durch Klicken auf den folgenden Link bestätigst du deine E-Mail: {emailConfirmU
     'user.error.phone_already_registered' => 'Benutzer mit dieser Telefonnummer ist bereits registriert.',
     'user.error.email_already_registered' => 'Benutzer mit dieser E-Mail ist bereits registriert.',
     'admin.notification.subject' => '{appName} Benachrichtigung',
+    'admin.notification.new_verified_user' => 'Ein neuer Benutzer hat gerade E-Mail und Telefon bestätigt. Bitte kontaktiere ihn für das Willkommens- / Onboarding-Gespräch.
+Name: {userName}
+E-Mail: {email}
+Telefon: {phone}',
     'admin.notification.sms_problem' => 'Problem mit SMS: {number}-{sms}',
     'admin.notification.sms_processed' => '{userName}: {message}',
     'admin.notification.duplicate_sms' => 'Problem mit SMS: {uuid}',

--- a/translations/messages+intl-icu.en.php
+++ b/translations/messages+intl-icu.en.php
@@ -221,6 +221,10 @@ By clicking the following link you will confirm your email: {emailConfirmURL}',
   'user.error.phone_already_registered' => 'User with this phone number already registered.',
   'user.error.email_already_registered' => 'User with this email already registered.',
   'admin.notification.subject' => '{appName} notification',
+  'admin.notification.new_verified_user' => 'New user has just verified email and phone. Please contact them for the welcome / onboarding call.
+Name: {userName}
+Email: {email}
+Phone: {phone}',
   'admin.notification.sms_problem' => 'Problem with SMS: {number}-{sms}',
   'admin.notification.sms_processed' => '{userName}: {message}',
   'admin.notification.duplicate_sms' => 'Problem with SMS: {uuid}',

--- a/translations/messages+intl-icu.sk.php
+++ b/translations/messages+intl-icu.sk.php
@@ -227,6 +227,10 @@ Kliknutím na nasledujúci odkaz potvrdíte svoj e-mail: {emailConfirmURL}',
     'user.error.phone_already_registered' => 'Používateľ s týmto telefónnym číslom je už registrovaný.',
     'user.error.email_already_registered' => 'Používateľ s týmto e-mailom je už registrovaný.',
     'admin.notification.subject' => '{appName} oznámenie',
+    'admin.notification.new_verified_user' => 'Nový používateľ práve potvrdil e-mail a telefón. Prosím, kontaktujte ho na uvítací / onboarding hovor.
+Meno: {userName}
+E-mail: {email}
+Telefón: {phone}',
     'admin.notification.sms_problem' => 'Problém s SMS: {number}-{sms}',
     'admin.notification.sms_processed' => '{userName}: {message}',
     'admin.notification.duplicate_sms' => 'Problém s SMS: {uuid}',

--- a/translations/messages+intl-icu.uk.php
+++ b/translations/messages+intl-icu.uk.php
@@ -227,6 +227,10 @@ return [
     'user.error.phone_already_registered' => 'Користувача з таким номером телефону вже зареєстровано.',
     'user.error.email_already_registered' => 'Користувача з таким email вже зареєстровано.',
     'admin.notification.subject' => '{appName} сповіщення',
+    'admin.notification.new_verified_user' => 'Новий користувач щойно підтвердив email і телефон. Будь ласка, зв\'яжіться з ним для привітання / онбордингу.
+Ім\'я: {userName}
+Email: {email}
+Телефон: {phone}',
     'admin.notification.sms_problem' => 'Проблема з SMS: {number}-{sms}',
     'admin.notification.sms_processed' => '{userName}: {message}',
     'admin.notification.duplicate_sms' => 'Проблема з SMS: {uuid}',


### PR DESCRIPTION
## Summary

Sends admins an email notification when a newly registered user completes both email **and** phone verification (or just email when `SMS_CONNECTOR` is empty — phone confirmation is unavailable in that mode), so the team can manually contact the newcomer for welcome / onboarding.

## Design

A new domain event `UserVerificationCompletedEvent(int $userId)` is dispatched from the three confirm sites:

- `EmailConfirmController` — after `EMAIL_CONFIRMED` history entry.
- `PhoneConfirmController` — after `PHONE_CONFIRMED` (web phone-confirm step 2).
- `Api/V1/UsersController::phoneConfirmVerify` — after `PHONE_CONFIRMED` (mobile-app path).

A single listener `NewUserAdminNotifierEventListener` re-loads the user, verifies state, and conditionally notifies via the existing `AdminNotifier`:

| `SMS_CONNECTOR` | Notification trigger |
|---|---|
| set (e.g. `eurosms`, `debug`) | after phone-confirm |
| empty | immediately after email-confirm (phone confirmation is unavailable) |

Email-only delivery (`bySms: false`) — body is multi-line with name/email/phone, not SMS-friendly. Per-admin localization is handled by `AdminNotifier` via existing `UserSettingsRepository` lookup.

## Idempotency

No DB schema change. Relies on natural control-flow guarantees:

- Email-confirm: registration row deleted on first click; second click returns "Registration key not found!" — no event dispatch.
- Phone-confirm: both `PhoneConfirmController` and API `UsersController` early-return when `isNumberConfirmed()` is already true.
- `UserConfirmedEmailChecker` blocks login until email is confirmed → in SMS-enabled deployments, phone-confirm always happens after email-confirm.

**Edge case (out-of-scope, documented):** if `SMS_CONNECTOR` is flipped from empty to set after a user already triggered the email-only notification, a subsequent phone confirmation would cause a second admin email for the same user. Niche migration scenario.

## Translations

Added `admin.notification.new_verified_user` key in `en`, `sk`, `cs`, `de`, `uk`. Subject reuses existing `admin.notification.subject`.

## Test plan

- [x] Unit tests cover all 4 listener branches × both SMS modes (6 cases) — `tests/Unit/EventListener/NewUserAdminNotifierEventListenerTest.php`
- [x] Integration: SMS-enabled full registration flow asserts admin email after phone-confirm — `tests/Application/Flow/RegistrationFlowTest.php`
- [x] Integration: SMS-disabled flow asserts admin email immediately after email-confirm — `tests/Application/Flow/SmsDisabledRegistrationFlowTest.php`
- [x] Integration: API mobile path asserts admin email after `phoneConfirmVerify` — `tests/Application/Flow/ApiPhoneConfirmAdminNotifyTest.php`
- [x] Full suite: 391/391 passing in Docker (`docker compose exec web vendor/bin/phpunit`)