### PR TITLE
feat(admin): invert filter behavior — empty selection shows all

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -289,12 +289,13 @@ function applyStandStatusToCard($card, status) {
 }
 
 function applyStandStatusFilter() {
-    const enabled = $('.stand-status-filter input[type="checkbox"]:checked')
+    const selected = $('.stand-status-filter input[type="checkbox"]:checked')
         .map(function () { return this.value; })
         .get();
+    const showAll = selected.length === 0;
     $('#standsconsole > .stand-col').each(function () {
         const status = $(this).find('.stand-status').val() || 'active';
-        $(this).toggle(enabled.includes(status));
+        $(this).toggle(showAll || selected.includes(status));
     });
 }
 
@@ -334,12 +335,13 @@ $(document).on('change', '.stand-status-filter input[type="checkbox"]', function
 const BIKE_STATUS_FILTER_STORAGE_KEY = 'admin.bikes.statusFilter';
 
 function applyBikeStatusFilter() {
-    const enabled = $('.bike-status-filter input[type="checkbox"]:checked')
+    const selected = $('.bike-status-filter input[type="checkbox"]:checked')
         .map(function () { return this.value; })
         .get();
+    const showAll = selected.length === 0;
     $('#fleetconsole > .bike-col').each(function () {
         const status = $(this).attr('data-bike-status') || 'ok';
-        $(this).toggle(enabled.includes(status));
+        $(this).toggle(showAll || selected.includes(status));
     });
 }
 

--- a/templates/admin/fleet.html.twig
+++ b/templates/admin/fleet.html.twig
@@ -8,8 +8,8 @@
     <div class="col-lg-12">
         <div class="btn-group btn-group-sm btn-group-toggle mb-2 bike-status-filter" data-toggle="buttons">
             {% for status in bikeStatuses %}
-                <label class="btn btn-outline-{{ status.color }} active">
-                    <input type="checkbox" autocomplete="off" value="{{ status.value }}" checked>
+                <label class="btn btn-outline-{{ status.color }}">
+                    <input type="checkbox" autocomplete="off" value="{{ status.value }}">
                     {% if status.icon %}<i class="fas {{ status.icon }}"></i>{% endif %}
                     {{ status.label|trans }}
                 </label>

--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -10,8 +10,8 @@
         <div class="col-lg-12 mt-3">
             <div class="btn-group btn-group-sm btn-group-toggle mb-3 stand-status-filter" data-toggle="buttons">
                 {% for status in standStatuses %}
-                    <label class="btn btn-outline-{{ status.color }} active">
-                        <input type="checkbox" autocomplete="off" value="{{ status.value }}" checked>
+                    <label class="btn btn-outline-{{ status.color }}">
+                        <input type="checkbox" autocomplete="off" value="{{ status.value }}">
                         {% if status.icon %}<i class="fas {{ status.icon }}"></i>{% endif %}
                         {{ status.label|trans }}
                     </label>


### PR DESCRIPTION
## Summary

Both admin filter pill-groups (Stands and Bikes) previously started with every status checked, so unchecking one hid that status, and unchecking everything hid every card. Inverted to the more conventional pattern: **no selection = no filter (show all); click a pill to narrow down**.

## Behavior matrix

| Selection | Before | After |
|---|---|---|
| 0 pills checked | hide everything | show everything |
| 1+ pills checked | show only checked | show only checked |
| Default (clean load) | all checked → show all | nothing checked → show all |

LocalStorage persistence still works in both directions — an empty saved array reproduces the "show all" state on reload.

## Diff

- `templates/admin/stands.html.twig`, `templates/admin/fleet.html.twig` — drop `checked` from input + `active` from label class on the filter pills.
- `public/js/admin.js` — `applyStandStatusFilter` / `applyBikeStatusFilter` now early-return show-all when zero pills are selected.

## Test plan

- [x] `bin/console lint:twig` clean.
- [x] PHPUnit 383/383 (template-only/JS-only — no PHP behavior change).
- [ ] Manual: `/admin` → Bikes / Stands tabs.
  - On first load (or after clearing localStorage) all cards visible, no pill highlighted.
  - Click "Rented" pill → only rented bikes visible.
  - Click again to deselect → empty selection → all visible again.
  - Reload → state preserved.