### PR TITLE
fix(admin): reset bike status filter when searching by bike number

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -186,6 +186,9 @@ function generateBikeCards(data) {
 }
 
 function bikeInfo(bikeNumber) {
+    if (bikeNumber) {
+        clearBikeStatusFilter();
+    }
     $.ajax({
         url: bikeNumber ? ("/api/v1/admin/bikes/" + bikeNumber) : "/api/v1/admin/bikes",
         method: "GET",
@@ -371,6 +374,14 @@ function saveBikeStatusFilter() {
     } catch (e) {
         // localStorage unavailable (private mode, quota) — filter still works in-session
     }
+}
+
+function clearBikeStatusFilter() {
+    $('.bike-status-filter input[type="checkbox"]').each(function () {
+        $(this).prop('checked', false);
+        $(this).closest('label').removeClass('active');
+    });
+    saveBikeStatusFilter();
 }
 
 $(document).on('change', '.bike-status-filter input[type="checkbox"]', function () {

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -382,6 +382,7 @@ function clearBikeStatusFilter() {
         $(this).closest('label').removeClass('active');
     });
     saveBikeStatusFilter();
+    applyBikeStatusFilter();
 }
 
 $(document).on('change', '.bike-status-filter input[type="checkbox"]', function () {


### PR DESCRIPTION
## Summary

The "Where is?" search box on the Fleet tab fetches a single bike, but the status filter pills (Problematic/Rented/OK) stayed active — if narrowed beforehand, the searched bike could be hidden by the filter and the admin had to manually clear it to see the result.

## Fix

Clear all filter pills (and persist the empty state to localStorage) whenever `bikeInfo()` is called with a specific bike number. The default no-arg call (full-list refresh on tab open) keeps the user's current filter.

```diff
 function bikeInfo(bikeNumber) {
+    if (bikeNumber) {
+        clearBikeStatusFilter();
+    }
     $.ajax({...});
 }
```

New helper `clearBikeStatusFilter()` unchecks all pills, removes the BS4 `.active` class on parent labels, and saves the empty array to localStorage so the cleared state persists on reload.

## Test plan

- [ ] /admin → Fleet tab → click "Rented" pill → only rented bikes visible.
- [ ] Enter a bike number that is currently OK in the search box → click "Where is?" → that bike's card is visible, filter pills are no longer highlighted.
- [ ] Reload page → filter still cleared (empty selection in localStorage = show-all).
- [ ] Click between admin tabs / re-open Fleet → list refreshes; current filter (cleared) preserved.