### PR TITLE
feat(auth): redirect already-authenticated users from /login to home

### DIFF
--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -20,6 +20,10 @@ class SecurityController extends AbstractController
         bool $isSmsSystemEnabled,
         AuthenticationUtils $authenticationUtils
     ): Response {
+        if ($this->getUser() !== null) {
+            return $this->redirectToRoute('home');
+        }
+
         $error = $authenticationUtils->getLastAuthenticationError();
         $lastUsername = $authenticationUtils->getLastUsername();
 

--- a/tests/Application/Controller/LoginControllerTest.php
+++ b/tests/Application/Controller/LoginControllerTest.php
@@ -57,4 +57,15 @@ class LoginControllerTest extends BikeSharingWebTestCase
         );
         $this->assertSame('de', $this->client->getRequest()->getSession()->get('_locale'));
     }
+
+    public function testAuthenticatedUserVisitingLoginPageIsRedirectedHome(): void
+    {
+        $user = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::USER_PHONE_NUMBER);
+        $this->client->loginUser($user);
+
+        $this->client->request(Request::METHOD_GET, '/login');
+
+        $this->assertResponseRedirects('/');
+    }
 }


### PR DESCRIPTION
Closes #99.

## Summary

When a user with a valid session (or a remember-me cookie that just got upgraded to a full session) navigates directly to `/login`, the controller currently re-renders the login form instead of taking them where they already have access. The original issue's UX ask: "skip the login screen, drop them straight on the rent/return/note screen for faster UX."

This PR adds a one-line guard in `SecurityController::login()` — if `$this->getUser()` resolves, redirect to `home` (`/`).

## What was already in place (no change needed)

- **Multi-device sessions** are already supported by Symfony's default session handling — logging in on phone B does not invalidate the session on phone A. The `remember_me_token` table is keyed on `series` (not `userId`), so each device gets its own remember-me row.
- **Remember-me** is wired up (1-week TTL, `TokenProvider`-backed, `_remember_me` checkbox checked-by-default in `templates/security/login.html.twig`). Returning users who tick the box stay logged in across visits.
- **JWT refresh tokens** for the mobile app are already family-scoped (`RefreshTokenRepository`), so multi-device API auth works independently per family.

The only operational gap was the GET `/login` no-op render. This PR fixes that.

## Test plan

- [x] New `LoginControllerTest::testAuthenticatedUserVisitingLoginPageIsRedirectedHome` — login a user via `loginUser()`, GET `/login`, assert 302 to `/`.
- [x] Existing `testLocaleSettingsOnLogin` still passes (not affected — it tests the POST flow).
- [x] Full suite **416/416 green** (was 415); PHPStan + PHPCS clean.