### PR TITLE
fix(gbfs): enforce enabled-locales on per-locale feeds + tighten security regex

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -20,11 +20,11 @@ ANDROID_APP_ENABLED=true
 #station_status / vehicle_types feeds consumed by Google Maps, Citymapper, Transit,
 #pybikes/citybik.es and similar aggregators. Set to false to return 404 on /gbfs/*.
 GBFS_ENABLED=true
-#Globally-unique system identifier (lowercase, no spaces). Required by the spec.
-#Recommended format: <operator>_<city>, e.g. cyklokoalicia_bratislava.
-GBFS_SYSTEM_ID=cyklokoalicia_bratislava
+#Globally-unique system identifier (no spaces). Required by the spec — pick a value
+#that uniquely identifies your deployment, e.g. <operator>_<city>.
+GBFS_SYSTEM_ID=opensourceBikeSharing
 #IANA timezone for the deployment (https://www.iana.org/time-zones).
-GBFS_TIMEZONE=Europe/Bratislava
+GBFS_TIMEZONE=UTC
 #Operator contact email surfaced in the system_information feed.
 GBFS_FEED_CONTACT_EMAIL=info@example.com
 #API connector used for SMS operations (connectors/ directory); empty to disable SMS system, "loopback" to simulate dummy gateway API for testing

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -128,7 +128,11 @@ return function (SecurityConfig $security) {
         ->roles(['PUBLIC_ACCESS']);
     $security
         ->accessControl()
-        ->path('^/gbfs(\.json|/)')
+        ->path('^/gbfs\.json$')
+        ->roles(['PUBLIC_ACCESS']);
+    $security
+        ->accessControl()
+        ->path('^/gbfs/')
         ->roles(['PUBLIC_ACCESS']);
     $security
         ->accessControl()

--- a/config/services.php
+++ b/config/services.php
@@ -94,7 +94,8 @@ return static function (ContainerConfigurator $container): void {
         ->bind('$isAndroidAppEnabled', env('bool:ANDROID_APP_ENABLED'));
 
     $services->get(\BikeShare\Controller\GbfsController::class)
-        ->bind('$isGbfsEnabled', env('bool:GBFS_ENABLED'));
+        ->bind('$isGbfsEnabled', env('bool:GBFS_ENABLED'))
+        ->bind('$enabledLocales', '%kernel.enabled_locales%');
 
     $services->get(\BikeShare\Gbfs\GbfsFeedBuilder::class)
         ->bind('$systemId', env('GBFS_SYSTEM_ID'))

--- a/src/Controller/GbfsController.php
+++ b/src/Controller/GbfsController.php
@@ -14,6 +14,8 @@ class GbfsController extends AbstractController
     public function __construct(
         private readonly bool $isGbfsEnabled,
         private readonly GbfsFeedBuilder $feedBuilder,
+        /** @var list<string> */
+        private readonly array $enabledLocales,
     ) {
     }
 
@@ -26,30 +28,39 @@ class GbfsController extends AbstractController
 
     public function systemInformation(string $locale): JsonResponse
     {
-        $this->guardEnabled();
+        $this->guard($locale);
 
         return new JsonResponse($this->feedBuilder->buildSystemInformation($locale));
     }
 
-    public function stationInformation(): JsonResponse
+    public function stationInformation(string $locale): JsonResponse
     {
-        $this->guardEnabled();
+        $this->guard($locale);
 
         return new JsonResponse($this->feedBuilder->buildStationInformation());
     }
 
-    public function stationStatus(): JsonResponse
+    public function stationStatus(string $locale): JsonResponse
     {
-        $this->guardEnabled();
+        $this->guard($locale);
 
         return new JsonResponse($this->feedBuilder->buildStationStatus());
     }
 
-    public function vehicleTypes(): JsonResponse
+    public function vehicleTypes(string $locale): JsonResponse
+    {
+        $this->guard($locale);
+
+        return new JsonResponse($this->feedBuilder->buildVehicleTypes());
+    }
+
+    private function guard(string $locale): void
     {
         $this->guardEnabled();
 
-        return new JsonResponse($this->feedBuilder->buildVehicleTypes());
+        if (!in_array($locale, $this->enabledLocales, true)) {
+            throw new NotFoundHttpException();
+        }
     }
 
     private function guardEnabled(): void

--- a/tests/Application/Controller/GbfsControllerTest.php
+++ b/tests/Application/Controller/GbfsControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Test\Application\Controller;
 
 use BikeShare\Test\Application\BikeSharingWebTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
 
 class GbfsControllerTest extends BikeSharingWebTestCase
@@ -111,5 +112,26 @@ class GbfsControllerTest extends BikeSharingWebTestCase
     {
         $this->client->request(Request::METHOD_GET, '/gbfs/xyz/system_information.json');
         $this->assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * `fr` passes the route's `[a-z]{2}` regex but is not in `kernel.enabled_locales`,
+     * so the manifest doesn't advertise it and the per-locale endpoints must reject it.
+     */
+    #[DataProvider('localeScopedFeedProvider')]
+    public function testNonEnabledLocaleReturns404(string $url): void
+    {
+        $this->client->request(Request::METHOD_GET, $url);
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public static function localeScopedFeedProvider(): array
+    {
+        return [
+            'system_information' => ['/gbfs/fr/system_information.json'],
+            'station_information' => ['/gbfs/fr/station_information.json'],
+            'station_status' => ['/gbfs/fr/station_status.json'],
+            'vehicle_types' => ['/gbfs/fr/vehicle_types.json'],
+        ];
     }
 }


### PR DESCRIPTION
Addresses [Qodo's review of #330](https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/330#issuecomment-4412923196). Three findings, all valid:

## Fixed

### 1. Locale not enforced (Qodo `🐞 Bug` / Correctness)
GBFS endpoints accepted any 2-letter locale (`[a-z]{2}` from the route), even ones not in `kernel.enabled_locales`. So `/gbfs/fr/system_information.json` returned 200 with `language: "fr"` despite `fr` not being advertised in `/gbfs.json`.

**Fix:** new `GbfsController::guard($locale)` validates `$locale` is in the deployment's enabled locales (`en/sk/cs/de/uk` by default) and throws `NotFoundHttpException` otherwise. Test: `testNonEnabledLocaleReturns404` (DataProvider over all 4 per-locale feeds).

### 2. Locale parameter ignored on 3 routes (Qodo `🐞 Bug` / Correctness)
`station_information`, `station_status`, and `vehicle_types` routes had `{locale}` in the path but the controller actions didn't accept `$locale`, so the parameter was unreachable for validation.

**Fix:** all 4 per-locale actions now accept `string $locale` and call the new `guard()` first. Builders aren't threaded through (they don't currently localize content — adding ignored params is just shape noise; revisit if/when content needs to vary per locale).

### 3. Overbroad security regex (Qodo `🐞 Bug` / Security)
`^/gbfs(\.json|/)` wasn't end-anchored on the `.json` branch, so `/gbfs.jsonanything` would have unintentionally matched `PUBLIC_ACCESS`.

**Fix:** split into two anchored rules — `^/gbfs\.json$` (exact) + `^/gbfs/` (subtree). Matches the same `PUBLIC_ACCESS` family pattern already used elsewhere in the file (each path family gets its own `accessControl()` block).

## Defaults updated

While here, made `.env.dist` deployment-agnostic:

| Var | Before | After |
|---|---|---|
| `GBFS_SYSTEM_ID` | `cyklokoalicia_bratislava` | `opensourceBikeSharing` |
| `GBFS_TIMEZONE` | `Europe/Bratislava` | `UTC` |

`.env.test` keeps its own values (`test_bikeshare`, `UTC`) — no test changes needed.

## Test plan

- [x] **New unit-style integration test** `testNonEnabledLocaleReturns404` — DataProvider over the 4 per-locale URLs with `fr` (passes route regex, fails locale guard) → all 4 return 404
- [x] Existing `testUnknownLocaleIs404` (3-letter locale `xyz`, route-regex layer) kept — defense in depth
- [x] Full suite: **427/427 green** (was 423, +4 new); PHPStan + PHPCS clean

## Out of scope

- LocaleGuard helper extraction — only 2 callsites in the codebase (here + `LanguageController`), one-line check; premature abstraction.
- Threading `$locale` into builder methods — currently not needed; revisit when content is actually localized per feed.

🤖 Acknowledging Qodo: thanks for catching these — locale enforcement was a real gap.