### PR TITLE
feat(gbfs): align station feeds with stand status semantics

### DIFF
--- a/src/Gbfs/GbfsFeedBuilder.php
+++ b/src/Gbfs/GbfsFeedBuilder.php
@@ -98,14 +98,16 @@ class GbfsFeedBuilder
         $now = $this->clock->now()->getTimestamp();
         $stations = [];
         foreach ($this->fetchPublicStands() as $stand) {
-            $isAvailable = StandStatus::from($stand['status'])->isRentablePublic();
+            // is_returning stays true even for TECHNICAL stands — returnBike()
+            // does not gate by stand status, so users can park there.
+            $isRentable = StandStatus::from($stand['status'])->isRentablePublic();
             $stations[] = [
                 'station_id' => (string)$stand['standId'],
                 'num_bikes_available' => (int)$stand['bikeCount'],
                 'num_docks_available' => null,
-                'is_installed' => $isAvailable,
-                'is_renting' => $isAvailable,
-                'is_returning' => $isAvailable,
+                'is_installed' => true,
+                'is_renting' => $isRentable,
+                'is_returning' => true,
                 'last_reported' => $now,
             ];
         }
@@ -132,12 +134,10 @@ class GbfsFeedBuilder
      */
     private function fetchPublicStands(): array
     {
-        $publicStatuses = array_filter(
-            StandStatus::cases(),
-            fn(StandStatus $s) => $s->isRentablePublic(),
-        );
-
-        return $this->standRepository->findAllExtended(null, array_values($publicStatuses));
+        // VIRTUAL is intentionally excluded — those stands are real rent endpoints
+        // (festivals, reserve storage) but carry placeholder lat/lng=0,0 that would
+        // render as Gulf-of-Guinea pins on aggregator maps.
+        return $this->standRepository->findAllExtended(null, [StandStatus::ACTIVE, StandStatus::TECHNICAL]);
     }
 
     private function envelope(int $ttl, array $data): array

--- a/tests/Application/Controller/GbfsControllerTest.php
+++ b/tests/Application/Controller/GbfsControllerTest.php
@@ -59,9 +59,14 @@ class GbfsControllerTest extends BikeSharingWebTestCase
         }
 
         $names = array_column($stations, 'name');
-        $this->assertNotContains('SERVICE_STAND', $names);
+        $this->assertContains(
+            'SERVICE_STAND',
+            $names,
+            'Maintenance stand must be advertised so clients can show it as out-of-service',
+        );
         $this->assertNotContains('HIDDEN_STAND', $names);
         $this->assertNotContains('INACTIVE_STAND', $names);
+        $this->assertNotContains('VIRTUAL_STAND', $names);
     }
 
     public function testStationStatusReportsBikeCounts(): void
@@ -78,10 +83,44 @@ class GbfsControllerTest extends BikeSharingWebTestCase
             $this->assertGreaterThanOrEqual(0, $station['num_bikes_available']);
             $this->assertNull($station['num_docks_available']);
             $this->assertTrue($station['is_installed']);
-            $this->assertTrue($station['is_renting']);
-            $this->assertTrue($station['is_returning']);
+            $this->assertIsBool($station['is_renting']);
+            $this->assertTrue($station['is_returning'], 'Every published stand accepts returns');
             $this->assertIsInt($station['last_reported']);
         }
+    }
+
+    public function testStationStatusMarksMaintenanceStandsNonRentable(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/gbfs/en/station_information.json');
+        $this->assertResponseIsSuccessful();
+        $infoByStationId = [];
+        foreach ($this->decodeJsonResponse()['data']['stations'] as $info) {
+            $infoByStationId[$info['station_id']] = $info;
+        }
+
+        $this->client->request(Request::METHOD_GET, '/gbfs/en/station_status.json');
+        $this->assertResponseIsSuccessful();
+        $statuses = $this->decodeJsonResponse()['data']['stations'];
+
+        $serviceStandStatus = null;
+        $activeStandStatus = null;
+        foreach ($statuses as $status) {
+            $name = $infoByStationId[$status['station_id']]['name'] ?? null;
+            if ($name === 'SERVICE_STAND') {
+                $serviceStandStatus = $status;
+            } elseif ($name === 'STAND1') {
+                $activeStandStatus = $status;
+            }
+        }
+
+        $this->assertNotNull($serviceStandStatus, 'SERVICE_STAND must appear in station_status');
+        $this->assertTrue($serviceStandStatus['is_installed'], 'Maintenance stand stays physically installed');
+        $this->assertFalse($serviceStandStatus['is_renting'], 'Maintenance stand must not be rentable');
+        $this->assertTrue($serviceStandStatus['is_returning'], 'Maintenance stand still accepts returns');
+
+        $this->assertNotNull($activeStandStatus, 'Sanity: active stand should appear too');
+        $this->assertTrue($activeStandStatus['is_renting']);
+        $this->assertTrue($activeStandStatus['is_returning']);
     }
 
     public function testVehicleTypesAdvertisesHumanBike(): void


### PR DESCRIPTION
## Summary

Make the GBFS feed accurately reflect stand-status semantics for aggregator consumers (Google Maps, Citymapper, Transit, pybikes/citybik.es, …):

- **VIRTUAL stands** (festivals, reserve storage) — **excluded**. They're real rent endpoints but carry placeholder coordinates and were surfacing at lat/lng `0, 0` on consumer maps. Flagged in [eskerda/pybikes#891](https://github.com/eskerda/pybikes/pull/891) as Gulf-of-Guinea pins.
- **TECHNICAL stands** (under maintenance) — **included with `is_renting=false`, `is_returning=true`**. Users with rented bikes can still park on a maintenance stand (`returnBike()` doesn't gate by status), only new rentals are blocked. GBFS 2.3 expresses this exactly via the per-flag granularity.

Net source set: `[ACTIVE, TECHNICAL]` (was: `[ACTIVE, VIRTUAL]` via `isRentablePublic()`).

## Per-flag mapping for published stands

| stand status | is_installed | is_renting | is_returning |
| --- | --- | --- | --- |
| ACTIVE | `true` | `true` | `true` |
| TECHNICAL | `true` | `false` | `true` |

## Changes

- `GbfsFeedBuilder::fetchPublicStands()`: filter to `[ACTIVE, TECHNICAL]`.
- `GbfsFeedBuilder::buildStationStatus()`:
  - `is_installed`: pinned `true` (physical presence is independent of rentability — was conflated via `isRentablePublic()`).
  - `is_renting`: driven by `isRentablePublic()` so TECHNICAL stands report as non-rentable.
  - `is_returning`: pinned `true` because `AbstractRentSystem::returnBike()` does not restrict by stand status.
- `GbfsControllerTest::testStationInformationExposesPublicStandsOnly`: assert `SERVICE_STAND` (technical) **is** present, `VIRTUAL_STAND` is not.
- `GbfsControllerTest::testStationStatusReportsBikeCounts`: assert `is_returning=true` for every published stand; `is_renting` is per-status (covered by the new test).
- `GbfsControllerTest::testStationStatusMarksMaintenanceStandsNonRentable` (new): joins `station_information` and `station_status`, verifies the maintenance stand has `is_installed=true / is_renting=false / is_returning=true` and that an active stand has `is_renting=true / is_returning=true`.

`StandStatus::isRentablePublic()` is **not** changed — virtual stands really are rentable in `AbstractRentSystem::process()` and `QrCodeGeneratorController`. The prior reuse of that method as the GBFS source-set filter was incidental.

## Test plan

- [x] `docker compose exec web vendor/bin/phpunit --filter GbfsController` — 12/12 pass.
- [ ] After deploy, verify:
  - `curl https://whitebikes.info/gbfs/en/station_information.json | jq '.data.stations[] | select(.lat == 0 and .lon == 0)'` returns empty.
  - `curl https://whitebikes.info/gbfs/en/station_status.json | jq '.data.stations[] | select(.is_renting == false and .is_returning == true)' | jq length` is non-zero (matches the count of technical stands).