### PR TITLE
feat(admin): show stand city + filter; hide stands tied to non-configured cities

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -291,51 +291,80 @@ function applyStandStatusToCard($card, status) {
     }
 }
 
-function applyStandStatusFilter() {
-    const selected = $('.stand-status-filter input[type="checkbox"]:checked')
-        .map(function () { return this.value; })
-        .get();
-    const showAll = selected.length === 0;
-    $('#standsconsole > .stand-col').each(function () {
-        const status = $(this).find('.stand-status').val() || 'active';
-        $(this).toggle(showAll || selected.includes(status));
-    });
-}
+const STAND_CITY_FILTER_STORAGE_KEY = 'admin.stands.cityFilter';
+const BIKE_STATUS_FILTER_STORAGE_KEY = 'admin.bikes.statusFilter';
 
-function loadStandStatusFilter() {
+function loadCheckboxFilter(selector, storageKey) {
     let enabled;
     try {
-        const saved = localStorage.getItem(STAND_STATUS_FILTER_STORAGE_KEY);
+        const saved = localStorage.getItem(storageKey);
         if (saved === null) return;
         enabled = JSON.parse(saved);
     } catch (e) {
         return;
     }
     if (!Array.isArray(enabled)) return;
-    $('.stand-status-filter input[type="checkbox"]').each(function () {
+    $(selector + ' input[type="checkbox"]').each(function () {
         const isChecked = enabled.includes(this.value);
         $(this).prop('checked', isChecked);
         $(this).closest('label').toggleClass('active', isChecked);
     });
 }
 
-function saveStandStatusFilter() {
-    const enabled = $('.stand-status-filter input[type="checkbox"]:checked')
+function saveCheckboxFilter(selector, storageKey) {
+    const enabled = $(selector + ' input[type="checkbox"]:checked')
         .map(function () { return this.value; })
         .get();
     try {
-        localStorage.setItem(STAND_STATUS_FILTER_STORAGE_KEY, JSON.stringify(enabled));
+        localStorage.setItem(storageKey, JSON.stringify(enabled));
     } catch (e) {
         // localStorage unavailable (private mode, quota) — filter still works in-session
     }
 }
 
+function applyStandFilters() {
+    const selectedStatuses = $('.stand-status-filter input[type="checkbox"]:checked')
+        .map(function () { return this.value; })
+        .get();
+    const selectedCities = $('.stand-city-filter input[type="checkbox"]:checked')
+        .map(function () { return this.value; })
+        .get();
+    const showAllStatuses = selectedStatuses.length === 0;
+    const showAllCities = selectedCities.length === 0;
+    $('#standsconsole > .stand-col').each(function () {
+        const status = $(this).find('.stand-status').val() || 'active';
+        const city = $(this).attr('data-stand-city') || '';
+        const statusMatch = showAllStatuses || selectedStatuses.includes(status);
+        const cityMatch = showAllCities || selectedCities.includes(city);
+        $(this).toggle(statusMatch && cityMatch);
+    });
+}
+
+function loadStandStatusFilter() {
+    loadCheckboxFilter('.stand-status-filter', STAND_STATUS_FILTER_STORAGE_KEY);
+}
+
+function saveStandStatusFilter() {
+    saveCheckboxFilter('.stand-status-filter', STAND_STATUS_FILTER_STORAGE_KEY);
+}
+
+function loadStandCityFilter() {
+    loadCheckboxFilter('.stand-city-filter', STAND_CITY_FILTER_STORAGE_KEY);
+}
+
+function saveStandCityFilter() {
+    saveCheckboxFilter('.stand-city-filter', STAND_CITY_FILTER_STORAGE_KEY);
+}
+
 $(document).on('change', '.stand-status-filter input[type="checkbox"]', function () {
     saveStandStatusFilter();
-    applyStandStatusFilter();
+    applyStandFilters();
 });
 
-const BIKE_STATUS_FILTER_STORAGE_KEY = 'admin.bikes.statusFilter';
+$(document).on('change', '.stand-city-filter input[type="checkbox"]', function () {
+    saveStandCityFilter();
+    applyStandFilters();
+});
 
 function applyBikeStatusFilter() {
     const selected = $('.bike-status-filter input[type="checkbox"]:checked')
@@ -349,31 +378,11 @@ function applyBikeStatusFilter() {
 }
 
 function loadBikeStatusFilter() {
-    let enabled;
-    try {
-        const saved = localStorage.getItem(BIKE_STATUS_FILTER_STORAGE_KEY);
-        if (saved === null) return;
-        enabled = JSON.parse(saved);
-    } catch (e) {
-        return;
-    }
-    if (!Array.isArray(enabled)) return;
-    $('.bike-status-filter input[type="checkbox"]').each(function () {
-        const isChecked = enabled.includes(this.value);
-        $(this).prop('checked', isChecked);
-        $(this).closest('label').toggleClass('active', isChecked);
-    });
+    loadCheckboxFilter('.bike-status-filter', BIKE_STATUS_FILTER_STORAGE_KEY);
 }
 
 function saveBikeStatusFilter() {
-    const enabled = $('.bike-status-filter input[type="checkbox"]:checked')
-        .map(function () { return this.value; })
-        .get();
-    try {
-        localStorage.setItem(BIKE_STATUS_FILTER_STORAGE_KEY, JSON.stringify(enabled));
-    } catch (e) {
-        // localStorage unavailable (private mode, quota) — filter still works in-session
-    }
+    saveCheckboxFilter('.bike-status-filter', BIKE_STATUS_FILTER_STORAGE_KEY);
 }
 
 function clearBikeStatusFilter() {
@@ -392,6 +401,7 @@ $(document).on('change', '.bike-status-filter input[type="checkbox"]', function 
 
 $(function () {
     loadStandStatusFilter();
+    loadStandCityFilter();
     loadBikeStatusFilter();
 });
 
@@ -404,9 +414,12 @@ function generateStandCards(data) {
         const $col = $template.clone().removeAttr("id").removeClass("d-none");
         const $card = $col.find('.stand-card');
         const status = item.status || 'active';
+        const city = item.city || '';
 
         $card.attr("data-stand-id", item.standId);
+        $col.attr("data-stand-city", city);
         $col.find(".stand-name").text(item.standName);
+        $col.find(".stand-city").text(city);
 
         const $photo = $col.find(".stand-photo");
         if (item.standPhoto) {
@@ -430,7 +443,7 @@ function generateStandCards(data) {
         $container.append($col);
     });
 
-    applyStandStatusFilter();
+    applyStandFilters();
 }
 
 $(document).on('click', '.stand-status-save', function () {
@@ -448,7 +461,7 @@ $(document).on('click', '.stand-status-save', function () {
         success: function (response) {
             const newStatus = (apiData(response) || {}).status || status;
             applyStandStatusToCard($card, newStatus);
-            applyStandStatusFilter();
+            applyStandFilters();
             $feedback
                 .removeClass('d-none text-danger')
                 .addClass('text-success')

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BikeShare\Controller;
 
 use BikeShare\Credit\CreditSystemInterface;
+use BikeShare\Repository\CityRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Clock\ClockInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,6 +16,7 @@ class AdminController extends AbstractController
         bool $isSmsSystemEnabled,
         CreditSystemInterface $creditSystem,
         ClockInterface $clock,
+        CityRepository $cityRepository,
     ): Response {
         return $this->render(
             'admin/index.html.twig',
@@ -22,6 +24,7 @@ class AdminController extends AbstractController
                 'isSmsSystemEnabled' => $isSmsSystemEnabled,
                 'creditSystem' => $creditSystem,
                 'currentYear' => $clock->now()->format('Y'),
+                'availableCities' => array_keys($cityRepository->findAvailableCities()),
             ]
         );
     }

--- a/src/Controller/Api/V1/Admin/StandsController.php
+++ b/src/Controller/Api/V1/Admin/StandsController.php
@@ -20,7 +20,7 @@ class StandsController extends AbstractController
 
     public function index(): Response
     {
-        $stands = $this->standRepository->findAll();
+        $stands = $this->standRepository->findAll(StandStatus::cases());
 
         return $this->json($stands);
     }

--- a/src/Controller/Api/V1/StandsController.php
+++ b/src/Controller/Api/V1/StandsController.php
@@ -60,10 +60,13 @@ class StandsController extends AbstractController
             $statuses[] = StandStatus::HIDDEN;
         }
 
-        if ($this->isGranted('ROLE_API') && !$this->isGranted('ROLE_USER')) {
-            $stands = $this->standRepository->findAllExtended(null, $statuses);
-        } else {
-            $stands = $this->standRepository->findAllExtended($this->getUser()->getCity(), $statuses);
+        $stands = $this->standRepository->findAll($statuses);
+        if (!$this->isGranted('ROLE_API') || $this->isGranted('ROLE_USER')) {
+            $userCity = $this->getUser()->getCity();
+            $stands = array_values(array_filter(
+                $stands,
+                fn(array $stand) => $stand['city'] === $userCity,
+            ));
         }
 
         return $this->json($stands);

--- a/src/Controller/PersonalStatsController.php
+++ b/src/Controller/PersonalStatsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller;
 
+use BikeShare\Enum\StandStatus;
 use BikeShare\Repository\StandRepository;
 use BikeShare\Repository\StatsRepository;
 use BikeShare\Repository\UserRepository;
@@ -31,7 +32,9 @@ class PersonalStatsController extends AbstractController
 
         $userId = $userRepository->findItemByPhoneNumber($this->getUser()->getUserIdentifier())['userId'];
         $stats = $statsRepository->getUserStatsForYear((int)$userId, (int)$year);
-        $standsList = $standRepository->findAll();
+        $standsList = $standRepository->findAll(
+            [StandStatus::ACTIVE, StandStatus::TECHNICAL, StandStatus::INACTIVE],
+        );
         $stands = [];
         foreach ($standsList as $stand) {
             $stands[$stand['standId']] = $stand;

--- a/src/Controller/QrCodeGeneratorController.php
+++ b/src/Controller/QrCodeGeneratorController.php
@@ -62,12 +62,8 @@ class QrCodeGeneratorController extends AbstractController
             );
         }
 
-        $stands = $standRepository->findAll();
+        $stands = $standRepository->findAll([StandStatus::ACTIVE, StandStatus::TECHNICAL]);
         foreach ($stands as $stand) {
-            if (!StandStatus::from($stand["status"])->isRentablePublic()) {
-                continue;
-            }
-
             $this->addPageQrCode(
                 $pdf,
                 $stand["standName"],

--- a/src/Gbfs/GbfsFeedBuilder.php
+++ b/src/Gbfs/GbfsFeedBuilder.php
@@ -136,8 +136,9 @@ class GbfsFeedBuilder
     {
         // VIRTUAL is intentionally excluded — those stands are real rent endpoints
         // (festivals, reserve storage) but carry placeholder lat/lng=0,0 that would
-        // render as Gulf-of-Guinea pins on aggregator maps.
-        return $this->standRepository->findAllExtended(null, [StandStatus::ACTIVE, StandStatus::TECHNICAL]);
+        // render as Gulf-of-Guinea pins on aggregator maps. Stands tied to cities
+        // not in CITIES env are filtered out at the repository level.
+        return $this->standRepository->findAll([StandStatus::ACTIVE, StandStatus::TECHNICAL]);
     }
 
     private function envelope(int $ttl, array $data): array

--- a/src/Repository/StandRepository.php
+++ b/src/Repository/StandRepository.php
@@ -10,36 +10,24 @@ use BikeShare\Enum\StandStatus;
 
 class StandRepository
 {
-    public function __construct(private readonly DbInterface $db)
-    {
-    }
-
-    public function findAll(): array
-    {
-        $result = $this->db->query(
-            "SELECT
-                standId,
-                standName,
-                standDescription,
-                standPhoto,
-                status,
-                placeName,
-                longitude,
-                latitude
-            FROM stands
-            ORDER BY standName"
-        )->fetchAllAssoc();
-
-        return $result;
+    public function __construct(
+        private readonly DbInterface $db,
+        private readonly CityRepository $cityRepository,
+    ) {
     }
 
     /**
      * @param StandStatus[] $statuses Statuses to include. Defaults to publicly visible (active + technical).
      */
-    public function findAllExtended(?string $city = null, array $statuses = []): array
+    public function findAll(array $statuses = []): array
     {
         if (empty($statuses)) {
             $statuses = [StandStatus::ACTIVE, StandStatus::TECHNICAL];
+        }
+
+        $cityParams = $this->buildCityParams();
+        if ($cityParams === null) {
+            return [];
         }
 
         $statusParams = [];
@@ -50,6 +38,8 @@ class StandRepository
             $statusPlaceholders[] = ':' . $key;
         }
 
+        $cityPlaceholders = array_map(fn(string $k) => ':' . $k, array_keys($cityParams));
+
         $result = $this->db->query(
             "SELECT
                 standId,
@@ -58,21 +48,38 @@ class StandRepository
                 standDescription,
                 standPhoto,
                 status,
+                city,
                 longitude,
                 latitude
             FROM stands
             LEFT JOIN bikes ON bikes.currentStand=stands.standId
-            WHERE stands.status IN (" . implode(', ', $statusPlaceholders) . ") " .
-            (is_null($city) ? " AND standId != :city " : " AND city = :city ") .
-            "GROUP BY standName
+            WHERE stands.status IN (" . implode(', ', $statusPlaceholders) . ")
+            AND city IN (" . implode(', ', $cityPlaceholders) . ")
+            GROUP BY standName
             ORDER BY standName",
-            array_merge(
-                $statusParams,
-                ['city' => (string)$city]
-            )
+            array_merge($statusParams, $cityParams)
         )->fetchAllAssoc();
 
         return $result;
+    }
+
+    /**
+     * @return array<string, string>|null Map of bind-name (no colon) → configured city,
+     *                                    or null if no cities are configured.
+     */
+    private function buildCityParams(): ?array
+    {
+        $names = array_keys($this->cityRepository->findAvailableCities());
+        if (empty($names)) {
+            return null;
+        }
+
+        $params = [];
+        foreach ($names as $i => $name) {
+            $params['city' . $i] = $name;
+        }
+
+        return $params;
     }
 
     public function findItem(int $standId): ?array

--- a/templates/admin/stands.html.twig
+++ b/templates/admin/stands.html.twig
@@ -17,14 +17,25 @@
                     </label>
                 {% endfor %}
             </div>
+            {% if availableCities|length > 1 %}
+                <div class="btn-group btn-group-sm btn-group-toggle mb-3 ml-2 stand-city-filter" data-toggle="buttons">
+                    {% for city in availableCities %}
+                        <label class="btn btn-outline-secondary">
+                            <input type="checkbox" autocomplete="off" value="{{ city }}">
+                            {{ city }}
+                        </label>
+                    {% endfor %}
+                </div>
+            {% endif %}
             <div class="row" id="standsconsole">
 
             </div>
             {# stand card#}
-            <div id="stand-card-template" class="d-none col-md-4 mb-4 stand-col">
+            <div id="stand-card-template" class="d-none col-md-4 mb-4 stand-col" data-stand-city="">
                 <div class="card stand-card border" data-stand-id="">
                     <div class="card-header">
                         <span class="stand-name"></span>
+                        <small class="stand-city text-muted ml-2"></small>
                         {% for status in standStatuses|filter(s => s.badgeClass) %}
                             <i class="fas {{ status.icon }} d-none {{ status.badgeClass }}"></i>
                         {% endfor %}

--- a/tests/Application/Controller/Api/Stand/AdminStandsListTest.php
+++ b/tests/Application/Controller/Api/Stand/AdminStandsListTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Controller\Api\Stand;
+
+use BikeShare\App\Security\UserProvider;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class AdminStandsListTest extends BikeSharingWebTestCase
+{
+    private const ADMIN_PHONE_NUMBER = '421951222222';
+
+    private string $originalCities;
+
+    protected function setUp(): void
+    {
+        $this->originalCities = $_ENV['CITIES'] ?? '';
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['CITIES'] = $this->originalCities;
+        parent::tearDown();
+    }
+
+    public function testSingleCityListIncludesCityAndExcludesNonConfigured(): void
+    {
+        $this->loginAdmin();
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/admin/stands');
+        $this->assertResponseIsSuccessful();
+
+        $names = $this->collectStandNamesAndAssertCity();
+
+        $this->assertContains('STAND1', $names);
+        $this->assertNotContains(
+            'ORPHAN_STAND',
+            $names,
+            'PhantomCity stand must be hidden in single-city deployment',
+        );
+        $this->assertNotContains(
+            'OTHER_CITY_STAND',
+            $names,
+            "Stand in 'Other City' must be hidden when only Default City is configured",
+        );
+    }
+
+    public function testMultiCityListIncludesEveryConfiguredCity(): void
+    {
+        $_ENV['CITIES'] = json_encode([
+            'Default City' => [48.148154, 17.117232],
+            'Other City' => [50.0, 20.0],
+        ]);
+        $this->loginAdmin();
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/admin/stands');
+        $this->assertResponseIsSuccessful();
+
+        $names = $this->collectStandNamesAndAssertCity();
+
+        $this->assertContains('STAND1', $names);
+        $this->assertContains(
+            'OTHER_CITY_STAND',
+            $names,
+            "Stand in 'Other City' must appear once 'Other City' is added to CITIES",
+        );
+        $this->assertNotContains(
+            'ORPHAN_STAND',
+            $names,
+            'PhantomCity stand must stay hidden — not in CITIES',
+        );
+    }
+
+    public function testEmptyCitiesConfigYieldsEmptyList(): void
+    {
+        $_ENV['CITIES'] = '{}';
+        $this->loginAdmin();
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/admin/stands');
+        $this->assertResponseIsSuccessful();
+
+        $stands = $this->decodeApiResponseData();
+        $this->assertSame(
+            [],
+            $stands,
+            'When no cities are configured, the admin list must be empty',
+        );
+    }
+
+    private function loginAdmin(): void
+    {
+        $admin = $this->client->getContainer()->get(UserProvider::class)
+            ->loadUserByIdentifier(self::ADMIN_PHONE_NUMBER);
+        $this->client->loginUser($admin);
+    }
+
+    /**
+     * @return list<string> stand names from the response, with `city` field assertions applied.
+     */
+    private function collectStandNamesAndAssertCity(): array
+    {
+        $stands = $this->decodeApiResponseData();
+        $this->assertNotEmpty($stands);
+
+        $names = [];
+        foreach ($stands as $stand) {
+            $this->assertArrayHasKey('city', $stand, 'Admin stand list must expose city');
+            $this->assertNotEmpty($stand['city']);
+            $names[] = $stand['standName'];
+        }
+
+        return $names;
+    }
+}

--- a/tests/Application/Controller/GbfsControllerTest.php
+++ b/tests/Application/Controller/GbfsControllerTest.php
@@ -67,6 +67,11 @@ class GbfsControllerTest extends BikeSharingWebTestCase
         $this->assertNotContains('HIDDEN_STAND', $names);
         $this->assertNotContains('INACTIVE_STAND', $names);
         $this->assertNotContains('VIRTUAL_STAND', $names);
+        $this->assertNotContains(
+            'ORPHAN_STAND',
+            $names,
+            'Stands tied to a non-configured city must be hidden from the public feed',
+        );
     }
 
     public function testStationStatusReportsBikeCounts(): void

--- a/tests/fixtures/stands.yaml
+++ b/tests/fixtures/stands.yaml
@@ -39,3 +39,17 @@ stdClass:
     standName: 'VIRTUAL_STAND'
     standDescription: '<streetName()>'
     status: 'virtual'
+
+  stand_orphan (extends defaultStand):
+    standId: '10'
+    standName: 'ORPHAN_STAND'
+    standDescription: '<streetName()>'
+    status: 'active'
+    city: 'PhantomCity'
+
+  stand_other_city (extends defaultStand):
+    standId: '11'
+    standName: 'OTHER_CITY_STAND'
+    standDescription: '<streetName()>'
+    status: 'active'
+    city: 'Other City'


### PR DESCRIPTION
## Summary

Two related fixes for the admin stand grid and the listing surfaces around it:

1. **Show city per stand + add a city filter** in `/admin`. Each card displays its city; a Bootstrap button-group filter (parallel to the existing status filter) lets admins narrow by city, persisted in `localStorage`. Filter UI auto-hides on single-city deployments.
2. **Hide stands tied to non-configured cities** from every list surface — admin grid, markers, GBFS. After PR #330 (`feat(gbfs): publish GBFS v2.3 feeds`) went live we observed legacy stands from cities removed from `CITIES` (Partizánske, Nové Zámky) still surfacing in the feed and admin UI until manually re-categorised in DB. This closes that gap permanently at the repository layer.

## Approach

`StandRepository::findAll()` and `findAllExtended()` collapse into one method:

```php
findAll(array $statuses = []): array
```

It always applies `WHERE city IN (configured CITIES)` and the requested status filter. Callers stay ignorant of the orphan-city rule and just request the statuses they care about. Point lookups (`findItem`, `findItemByName`) are intentionally untouched so an in-flight bike rental can still return to a just-orphaned stand.

Per-user-city narrowing (markers UI) is no longer a repo parameter — it's a one-line `array_filter` in the markers controller, the only place that needs it.

## Caller status maps

| Surface | Statuses passed to `findAll()` |
| --- | --- |
| `/api/v1/stands/markers` (web map) | `[ACTIVE, TECHNICAL]` (`+HIDDEN` for admin) — caller post-filters by user's city |
| GBFS `station_information` / `station_status` | `[ACTIVE, TECHNICAL]` |
| `/api/v1/admin/stands` (admin grid) | `StandStatus::cases()` (every status) |
| `PersonalStatsController` | `[ACTIVE, TECHNICAL, INACTIVE]` — historical stats keep names for decommissioned/maintenance stands; `VIRTUAL` stays out |
| `QrCodeGeneratorController` | `[ACTIVE, TECHNICAL]` — real physical stands worth printing labels for; orphans no longer get printable QRs |

## Files

- `src/Repository/StandRepository.php` — `CityRepository` injected; `findAll(array $statuses)` with bound `WHERE city IN (...)`; `findAllExtended()` removed; `findItem`/`findItemByName` untouched.
- `src/Controller/Api/V1/Admin/StandsController.php`, `src/Controller/Api/V1/StandsController.php`, `src/Gbfs/GbfsFeedBuilder.php`, `src/Controller/PersonalStatsController.php`, `src/Controller/QrCodeGeneratorController.php` — updated to the new signature with status sets per the table above.
- `src/Controller/AdminController.php` — passes `availableCities` to the admin Twig context.
- `templates/admin/stands.html.twig` — `.stand-city-filter` button group (auto-hidden when fewer than two cities are configured) and `<small class="stand-city">` in the card template.
- `public/js/admin.js` — extracted `loadCheckboxFilter` / `saveCheckboxFilter` helpers so the three filter trios (stand-status, stand-city, bike-status) all delegate to them; status + city compose through a single `applyStandFilters()` pass.
- `tests/Application/Controller/Api/Stand/AdminStandsListTest.php` (new) — single-city, multi-city (env override), and empty-`CITIES` scenarios. Uses the `$_ENV['CITIES']` capture/restore pattern from `UserChangeCityTest` / `CreditHistoryControllerTest`.
- `tests/Application/Controller/GbfsControllerTest.php` — orphan-stand exclusion assertion.
- `tests/fixtures/stands.yaml` — `ORPHAN_STAND` (`city: PhantomCity`) and `OTHER_CITY_STAND` (`city: 'Other City'`).

No DB migrations.

## Test plan

- [x] `docker compose exec web vendor/bin/phpunit` — 431 tests, only the pre-existing flakies (`AuthFlow`, `LoginController`, `UserController`, `ApiPhoneConfirmAdminNotify`) remain unrelated.
- [x] `docker compose exec web vendor/bin/phpunit --filter 'AdminStandsListTest|GbfsControllerTest|StandMarkersTest|StandUpdateStatusTest'` — 28/28.
- [x] `docker compose exec web vendor/bin/phpcs ./src ./tests` — clean.
- [ ] Smoke after deploy:
  - With multi-city `CITIES`: admin grid shows the city per card and the city filter group appears.
  - `INSERT INTO stands … city='Lviv', status='active'` (city not in `CITIES`) — does not appear in `/admin`, `/api/v1/stands/markers`, `/gbfs/en/station_information.json`.
  - Single-city deploy: city filter group hidden.