### PR TITLE
feat(admin): track Android version on me/trips and me/credit-history

### DIFF
--- a/src/App/EventListener/AndroidVersionSubscriber.php
+++ b/src/App/EventListener/AndroidVersionSubscriber.php
@@ -17,15 +17,12 @@ class AndroidVersionSubscriber implements EventSubscriberInterface
     private const PLATFORM_ANDROID = 'android';
 
     // High-frequency endpoints (map polling, per-screen calls) that would otherwise
-    // trigger a no-op throttled write on every request. Tracked endpoints (login,
-    // refresh, rentals, returns, admin actions) cover real user activity.
+    // trigger a no-op throttled write on every request.
     private const SKIPPED_ROUTES = [
         'api_v1_stand_markers' => true,
         'api_v1_me_city' => true,
         'api_v1_me_bikes' => true,
         'api_v1_me_limits' => true,
-        'api_v1_me_credit_history' => true,
-        'api_v1_me_trips' => true,
     ];
 
     public function __construct(

--- a/tests/Unit/App/EventListener/AndroidVersionSubscriberTest.php
+++ b/tests/Unit/App/EventListener/AndroidVersionSubscriberTest.php
@@ -65,8 +65,6 @@ class AndroidVersionSubscriberTest extends TestCase
             'me/limits per-screen' => ['/api/v1/me/limits', 'api_v1_me_limits'],
             'me/bikes per-screen' => ['/api/v1/me/bikes', 'api_v1_me_bikes'],
             'me/city patch' => ['/api/v1/me/city', 'api_v1_me_city'],
-            'me/credit-history' => ['/api/v1/me/credit-history', 'api_v1_me_credit_history'],
-            'me/trips' => ['/api/v1/me/trips', 'api_v1_me_trips'],
         ];
     }
 


### PR DESCRIPTION
## Summary
- Remove `api_v1_me_trips` and `api_v1_me_credit_history` from `AndroidVersionSubscriber::SKIPPED_ROUTES` so they record client version on hit.
- These endpoints are per-screen (not high-frequency polling like `stands/markers` or `me/limits`), so the throttled write cost is negligible and they meaningfully widen coverage for users who don't trigger a rental/return in a session.
- Drop the now-stale "(login, refresh, …) cover real user activity" comment — those `auth/*` routes are `PUBLIC_ACCESS` and `Security::getUser()` returns null there, so they never recorded anyway.

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/App/EventListener/AndroidVersionSubscriberTest.php` — 10/10
- [x] `vendor/bin/phpunit tests/Application/Controller/Api/ClientVersionTrackingTest.php` — 8/8