### PR TITLE
chore(sentry): sample GBFS traces at 1%

### DIFF
--- a/config/packages/prod/sentry.php
+++ b/config/packages/prod/sentry.php
@@ -1,15 +1,12 @@
 <?php
 
-use BikeShare\Sentry\GbfsTracesSampler;
-use Symfony\Config\SentryConfig;
-
-return static function (SentryConfig $sentry) {
+return static function (\Symfony\Config\SentryConfig $sentry) {
     $sentry->dsn('%env(SENTRY_DSN)%');
     $sentry->options()
         ->httpConnectTimeout(2)
         ->httpTimeout(2)
         ->defaultIntegrations(true)
-        ->tracesSampler(GbfsTracesSampler::class)
+        ->tracesSampler(\BikeShare\Sentry\GbfsTracesSampler::class)
         ->attachStacktrace(true)
         ->ignoreExceptions([
             \Symfony\Component\Security\Core\Exception\AccessDeniedException::class,

--- a/config/packages/prod/sentry.php
+++ b/config/packages/prod/sentry.php
@@ -1,5 +1,6 @@
 <?php
 
+use BikeShare\Sentry\GbfsTracesSampler;
 use Symfony\Config\SentryConfig;
 
 return static function (SentryConfig $sentry) {
@@ -8,7 +9,7 @@ return static function (SentryConfig $sentry) {
         ->httpConnectTimeout(2)
         ->httpTimeout(2)
         ->defaultIntegrations(true)
-        ->tracesSampleRate(1.0)
+        ->tracesSampler(GbfsTracesSampler::class)
         ->attachStacktrace(true)
         ->ignoreExceptions([
             \Symfony\Component\Security\Core\Exception\AccessDeniedException::class,

--- a/src/Sentry/GbfsTracesSampler.php
+++ b/src/Sentry/GbfsTracesSampler.php
@@ -7,7 +7,7 @@ namespace BikeShare\Sentry;
 use Sentry\Tracing\SamplingContext;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-final readonly class GbfsTracesSampler
+readonly class GbfsTracesSampler
 {
     public function __construct(private RequestStack $requestStack)
     {

--- a/src/Sentry/GbfsTracesSampler.php
+++ b/src/Sentry/GbfsTracesSampler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Sentry;
+
+use Sentry\Tracing\SamplingContext;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final readonly class GbfsTracesSampler
+{
+    public function __construct(private RequestStack $requestStack)
+    {
+    }
+
+    public function __invoke(SamplingContext $context): float
+    {
+        $request = $this->requestStack->getMainRequest();
+        if ($request !== null && str_starts_with($request->getPathInfo(), '/gbfs')) {
+            return 0.01;
+        }
+
+        return 1.0;
+    }
+}

--- a/tests/Unit/Sentry/GbfsTracesSamplerTest.php
+++ b/tests/Unit/Sentry/GbfsTracesSamplerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Unit\Sentry;
+
+use BikeShare\Sentry\GbfsTracesSampler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sentry\Tracing\SamplingContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class GbfsTracesSamplerTest extends TestCase
+{
+    #[DataProvider('pathProvider')]
+    public function testSampleRateForPath(?string $path, float $expected): void
+    {
+        $requestStack = new RequestStack();
+        if ($path !== null) {
+            $requestStack->push(Request::create($path));
+        }
+
+        $sampler = new GbfsTracesSampler($requestStack);
+
+        $this->assertSame($expected, $sampler(new SamplingContext()));
+    }
+
+    public static function pathProvider(): iterable
+    {
+        yield 'gbfs manifest' => ['/gbfs.json', 0.01];
+        yield 'gbfs station status' => ['/gbfs/en/station_status.json', 0.01];
+        yield 'gbfs vehicle types' => ['/gbfs/sk/vehicle_types.json', 0.01];
+        yield 'regular admin page' => ['/admin', 1.0];
+        yield 'home' => ['/', 1.0];
+        yield 'no main request (CLI/messenger)' => [null, 1.0];
+    }
+}


### PR DESCRIPTION
## Summary
- GBFS feeds are polled frequently by external aggregators (pybikes, MobilityData), producing the vast majority of Sentry performance transactions.
- Add a `traces_sampler` service (`BikeShare\Sentry\GbfsTracesSampler`) that returns `0.01` for requests under `/gbfs*` and `1.0` for everything else.
- Replaces the unconditional `traces_sample_rate: 1.0` in `config/packages/prod/sentry.php`.
- Errors are not affected — sampling applies only to performance traces.

## Test plan
- [x] `vendor/bin/phpunit tests/Unit/Sentry/GbfsTracesSamplerTest.php` — 6/6 green (covers `/gbfs.json`, per-locale GBFS paths, `/admin`, `/`, and the no-main-request CLI/messenger case)
- [x] `bin/console cache:clear --env=prod --no-debug` — prod container compiles without errors, confirming the bundle resolves the service id via the standard `BikeShare\\` autoload
- [ ] After deploy: observe Sentry Performance dashboard with `transaction:GET /gbfs/*` — volume should drop ~100×