### PR TITLE
style(welcome): center layout, responsive flex grid for chat cards

### DIFF
--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -1,17 +1,33 @@
+.welcome-wrap {
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.welcome-chats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    justify-content: center;
+}
+
 .welcome-card {
-    height: 100%;
+    flex: 1 1 280px;
+    max-width: 360px;
+}
+
+.welcome-card .card-body {
+    padding: 1.75rem 1.25rem;
 }
 
 .welcome-card .messenger-icon {
-    width: 48px;
-    height: 48px;
+    width: 56px;
+    height: 56px;
     color: #495057;
 }
 
 .welcome-card .qr-wrap {
     display: flex;
     justify-content: center;
-    margin-top: 1rem;
 }
 
 .welcome-card .qr-wrap svg {

--- a/templates/welcome.html.twig
+++ b/templates/welcome.html.twig
@@ -8,37 +8,35 @@
 {% endblock %}
 
 {% block body %}
-    <div class="my-4">
-        <h1>{{ 'welcome.title'|trans({siteName: siteName}) }}</h1>
-        <p class="lead">{{ 'welcome.description'|trans }}</p>
+    <div class="welcome-wrap text-center">
+        <h1 class="mt-5 mb-3">{{ 'welcome.title'|trans({siteName: siteName}) }}</h1>
+        <p class="lead mb-5">{{ 'welcome.description'|trans }}</p>
 
-        <div class="row mt-4">
+        <div class="welcome-chats">
             {% for chat in chats %}
-                <div class="col-md-6 col-lg-4 mb-4">
-                    <div class="card welcome-card">
-                        <div class="card-body text-center">
-                            <img class="messenger-icon mb-3"
-                                 src="{{ asset('assets/messengers/' ~ chat.icon.value ~ '.svg') }}"
-                                 alt="{{ chat.icon.value }}">
-                            <h5 class="card-title">{{ chat.name }}</h5>
-                            <a class="btn btn-primary"
-                               href="{{ chat.url }}"
-                               target="_blank"
-                               rel="noopener noreferrer">
-                                <i class="fas fa-external-link-alt mr-1"></i>{{ 'welcome.openChat'|trans }}
-                            </a>
-                            <div class="qr-wrap">
-                                {{ qr_svg(chat.url) }}
-                            </div>
-                            <small class="text-muted d-block mt-2">{{ 'welcome.scanQr'|trans }}</small>
+                <div class="welcome-card card shadow-sm">
+                    <div class="card-body">
+                        <img class="messenger-icon mb-3"
+                             src="{{ asset('assets/messengers/' ~ chat.icon.value ~ '.svg') }}"
+                             alt="{{ chat.icon.value }}">
+                        <h5 class="card-title">{{ chat.name }}</h5>
+                        <a class="btn btn-primary btn-lg mt-2"
+                           href="{{ chat.url }}"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                            <i class="fas fa-external-link-alt mr-1"></i>{{ 'welcome.openChat'|trans }}
+                        </a>
+                        <div class="qr-wrap mt-4">
+                            {{ qr_svg(chat.url) }}
                         </div>
+                        <small class="text-muted d-block mt-2">{{ 'welcome.scanQr'|trans }}</small>
                     </div>
                 </div>
             {% endfor %}
         </div>
 
-        <form method="post" action="{{ path('welcome_dismiss') }}" class="mt-3">
-            <button type="submit" class="btn btn-link" name="welcome_skip">{{ 'welcome.skip'|trans }}</button>
+        <form method="post" action="{{ path('welcome_dismiss') }}" class="mt-4 mb-5">
+            <button type="submit" class="btn btn-link">{{ 'welcome.skip'|trans }}</button>
         </form>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Follow-up to #338. The welcome page rendered left-aligned with a narrow card in a 3-col Bootstrap grid even when only one chat was configured, leaving most of the screen empty.

- Center-aligned heading, lead text, and skip link
- Container `max-width: 760px; margin: 0 auto`
- Chat cards in a flex container with `flex-wrap` and `justify-content: center` — single card stays compact and centered, multiple cards sit side by side and wrap on narrow viewports
- `shadow-sm` on the card, larger `btn-lg` for the primary action, slightly larger messenger icon

## Test plan

- [x] `docker compose exec web vendor/bin/phpunit tests/Application/Controller/WelcomeControllerTest.php` — 7/7 green
- [ ] Manual: open `/welcome` with 1 chat → card centered under heading, balanced spacing
- [ ] Manual: open `/welcome` with 3+ chats → cards in a wrapping row, all centered