### PR TITLE
style(welcome): horizontal card + centered QR scaling

### DIFF
--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -5,32 +5,52 @@
 
 .welcome-chats {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 1.5rem;
-    justify-content: center;
+    align-items: center;
 }
 
 .welcome-card {
-    flex: 1 1 280px;
-    max-width: 360px;
+    width: 100%;
+    max-width: 560px;
 }
 
 .welcome-card .card-body {
-    padding: 1.75rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2rem 1.5rem;
+}
+
+.welcome-card-info,
+.welcome-card-qr {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    flex: 1 1 0;
+    min-width: 0;
 }
 
 .welcome-card .messenger-icon {
-    width: 56px;
-    height: 56px;
+    width: 64px;
+    height: 64px;
     color: #495057;
 }
 
-.welcome-card .qr-wrap {
-    display: flex;
-    justify-content: center;
-}
-
-.welcome-card .qr-wrap svg {
+.welcome-card-qr svg {
     width: 160px;
     height: 160px;
+}
+
+@media (min-width: 576px) {
+    .welcome-card .card-body {
+        flex-direction: row;
+        gap: 2rem;
+    }
+    .welcome-card-info {
+        border-right: 1px solid #e9ecef;
+        padding-right: 2rem;
+    }
 }

--- a/src/Twig/QrCodeExtension.php
+++ b/src/Twig/QrCodeExtension.php
@@ -20,7 +20,19 @@ class QrCodeExtension extends AbstractExtension
     public function qrSvg(string $text, int $modulePx = 4): string
     {
         $barcode = new TCPDF2DBarcode($text, 'QRCODE,M');
+        $svg = $barcode->getBarcodeSVGcode($modulePx, $modulePx, 'black');
 
-        return $barcode->getBarcodeSVGcode($modulePx, $modulePx, 'black');
+        // TCPDF emits width/height but omits viewBox, so CSS-resized SVGs keep their
+        // pattern in the top-left corner. Inject viewBox so the QR scales centered.
+        if (preg_match('/<svg\s+width="(\d+)"\s+height="(\d+)"/', $svg, $m) === 1) {
+            $svg = preg_replace(
+                '/<svg\s+/',
+                '<svg viewBox="0 0 ' . $m[1] . ' ' . $m[2] . '" preserveAspectRatio="xMidYMid meet" ',
+                $svg,
+                1,
+            );
+        }
+
+        return $svg;
     }
 }

--- a/templates/welcome.html.twig
+++ b/templates/welcome.html.twig
@@ -16,20 +16,22 @@
             {% for chat in chats %}
                 <div class="welcome-card card shadow-sm">
                     <div class="card-body">
-                        <img class="messenger-icon mb-3"
-                             src="{{ asset('assets/messengers/' ~ chat.icon.value ~ '.svg') }}"
-                             alt="{{ chat.icon.value }}">
-                        <h5 class="card-title">{{ chat.name }}</h5>
-                        <a class="btn btn-primary btn-lg mt-2"
-                           href="{{ chat.url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">
-                            <i class="fas fa-external-link-alt mr-1"></i>{{ 'welcome.openChat'|trans }}
-                        </a>
-                        <div class="qr-wrap mt-4">
-                            {{ qr_svg(chat.url) }}
+                        <div class="welcome-card-info">
+                            <img class="messenger-icon mb-3"
+                                 src="{{ asset('assets/messengers/' ~ chat.icon.value ~ '.svg') }}"
+                                 alt="{{ chat.icon.value }}">
+                            <h4 class="card-title mb-3">{{ chat.name }}</h4>
+                            <a class="btn btn-primary btn-lg"
+                               href="{{ chat.url }}"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                <i class="fas fa-external-link-alt mr-1"></i>{{ 'welcome.openChat'|trans }}
+                            </a>
                         </div>
-                        <small class="text-muted d-block mt-2">{{ 'welcome.scanQr'|trans }}</small>
+                        <div class="welcome-card-qr">
+                            {{ qr_svg(chat.url) }}
+                            <small class="text-muted d-block mt-2">{{ 'welcome.scanQr'|trans }}</small>
+                        </div>
                     </div>
                 </div>
             {% endfor %}


### PR DESCRIPTION
## Summary

Follow-up to #339. The card was still vertical and tall (icon → name → button → QR stacked), leaving large empty bands on both sides. Two changes:

### Horizontal card layout
- Split card body into two columns on ≥576px: **left** — messenger icon (64px) + chat name + Open chat button; **right** — QR + scan caption. Thin divider between.
- Card `max-width: 560px` so the horizontal layout breathes.
- Stacks vertically on narrow viewports.

### QR centering fix
- `TCPDF2DBarcode` emits `<svg width="N" height="N">` without `viewBox`. When CSS scales the SVG (160×160 from natural 116×116), the pattern stays in the top-left corner of the resized box.
- `QrCodeExtension::qrSvg` now injects `viewBox` + `preserveAspectRatio="xMidYMid meet"` via `preg_replace` so the QR fills and centers inside the CSS-sized SVG.

## Test plan

- [x] `vendor/bin/phpunit tests/Application/Controller/WelcomeControllerTest.php` — 7/7
- [ ] Manual: open `/welcome` with 1 chat → horizontal card, QR centered in its column
- [ ] Manual: shrink viewport <576px → card stacks vertically
- [ ] Manual: multiple chats → cards stack vertically, each full-width