### PR TITLE
Enforce email verification on the api_v1 firewall (spec 0003)

### DIFF
--- a/config/packages/framework.php
+++ b/config/packages/framework.php
@@ -27,6 +27,14 @@ return static function (FrameworkConfig $framework): void {
         ->defaultLifetime(180)
         ->public(true);
 
+    // Persistent (cross-request) pool used to throttle reconfirmation emails: the email
+    // checker runs on every authenticated request, so the listener writes a per-user marker
+    // here and skips re-sending while it lives. Filesystem-backed; default lifetime = window.
+    $cache->pool('cache.reconfirmation_throttle')
+        ->adapters(['cache.adapter.filesystem'])
+        ->defaultLifetime(900)
+        ->public(true);
+
     $framework
         ->defaultLocale('en')
         ->enabledLocales(['en', 'sk', 'cs', 'de', 'uk'])

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -45,6 +45,7 @@ return function (SecurityConfig $security) {
         ->security(true)
         ->pattern('^/api/v1')
         ->context('main')
+        ->userChecker(UserConfirmedEmailChecker::class)
         ->accessDeniedHandler(ApiAccessDeniedHandler::class)
         ->entryPoint(ApiV1Authenticator::class);
     $apiFirewall

--- a/config/services.php
+++ b/config/services.php
@@ -272,4 +272,7 @@ return static function (ContainerConfigurator $container): void {
     $services->get(\BikeShare\EventListener\LongStandBonusEventListener::class)
         ->bind('$longStandDays', env('int:CREDIT_SYSTEM_LONG_STAND_DAYS'))
         ->bind('$longStandBonus', env('float:CREDIT_SYSTEM_LONG_STAND_BONUS'));
+
+    $services->get(\BikeShare\EventListener\ReconfirmationEventListener::class)
+        ->bind('$cache', service('cache.reconfirmation_throttle'));
 };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,6 +38,8 @@ paths:
           $ref: "#/components/responses/Problem"
         "401":
           $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /auth/refresh:
     post:
       summary: Rotate refresh token and return new tokens
@@ -63,6 +65,8 @@ paths:
           $ref: "#/components/responses/Problem"
         "401":
           $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /auth/logout:
     post:
       summary: Revoke refresh token family
@@ -150,7 +154,7 @@ paths:
         "200":
           $ref: "#/components/responses/Success"
         "403":
-          $ref: "#/components/responses/PhoneUnconfirmed"
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/Problem"
   /stands/markers:
@@ -160,7 +164,7 @@ paths:
         "200":
           $ref: "#/components/responses/Success"
         "403":
-          $ref: "#/components/responses/PhoneUnconfirmed"
+          $ref: "#/components/responses/Forbidden"
   /admin/bikes/{bikeNumber}:
     get:
       summary: Bike details (admin)
@@ -204,7 +208,7 @@ paths:
         "200":
           $ref: "#/components/responses/Success"
         "403":
-          $ref: "#/components/responses/PhoneUnconfirmed"
+          $ref: "#/components/responses/Forbidden"
         "409":
           $ref: "#/components/responses/Problem"
   /returns:
@@ -228,7 +232,7 @@ paths:
         "200":
           $ref: "#/components/responses/Success"
         "403":
-          $ref: "#/components/responses/PhoneUnconfirmed"
+          $ref: "#/components/responses/Forbidden"
         "409":
           $ref: "#/components/responses/Problem"
   /me/bikes:
@@ -238,7 +242,7 @@ paths:
         "200":
           $ref: "#/components/responses/Success"
         "403":
-          $ref: "#/components/responses/PhoneUnconfirmed"
+          $ref: "#/components/responses/Forbidden"
   /me/limits:
     get:
       summary: Current user limits and credit
@@ -246,7 +250,7 @@ paths:
         "200":
           $ref: "#/components/responses/Success"
         "403":
-          $ref: "#/components/responses/PhoneUnconfirmed"
+          $ref: "#/components/responses/Forbidden"
   /me/city:
     patch:
       summary: Change current user city
@@ -533,27 +537,47 @@ components:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
-    PhoneUnconfirmed:
+    Forbidden:
       description: >-
-        Returned by any authenticated endpoint (except the auth and
-        phone-confirmation routes) when the SMS system is enabled and the
-        caller's phone number is not yet confirmed. The caller holds
-        ROLE_NEWBIE and must confirm their phone first. This is a standard
-        Problem Details response carrying the stable extension
-        `code: phone_unconfirmed`; clients should branch on `code` rather than
-        the human-readable `detail`.
+        Returned by authenticated endpoints when the caller is authenticated
+        but not permitted to use the API yet. Two stable extension codes can
+        appear:
+
+        - `email_unconfirmed`: the account still has a pending email
+          confirmation (a `registration` token row). Enforced per request on
+          the `api_v1` firewall via the same `UserChecker` as web login, so a
+          token issued before the account lapsed stops working immediately.
+          Resolve out-of-band via the email confirmation link.
+
+        - `phone_unconfirmed`: the SMS system is enabled and the caller's phone
+          number is not yet confirmed. The caller holds ROLE_NEWBIE and must
+          confirm their phone first (see the phone-confirmation routes).
+
+        Both are standard Problem Details responses; clients should branch on
+        the `code` extension rather than the human-readable `detail`.
       content:
         application/problem+json:
           schema:
             $ref: "#/components/schemas/Problem"
-          example:
-            type: about:blank
-            title: Forbidden
-            status: 403
-            detail: Phone number must be confirmed.
-            instance: /api/v1/me/bikes
-            requestId: 0190a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b
-            code: phone_unconfirmed
+          examples:
+            emailUnconfirmed:
+              value:
+                type: about:blank
+                title: Forbidden
+                status: 403
+                detail: User does not confirmed email. Check your email for confirmation letter.
+                instance: /api/v1/me/bikes
+                requestId: 0190a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b
+                code: email_unconfirmed
+            phoneUnconfirmed:
+              value:
+                type: about:blank
+                title: Forbidden
+                status: 403
+                detail: Phone number must be confirmed.
+                instance: /api/v1/me/bikes
+                requestId: 0190a1b2-c3d4-7e5f-8a9b-0c1d2e3f4a5b
+                code: phone_unconfirmed
   schemas:
     SuccessEnvelope:
       type: object

--- a/src/App/Security/ApiV1Authenticator.php
+++ b/src/App/Security/ApiV1Authenticator.php
@@ -62,6 +62,13 @@ class ApiV1Authenticator extends AbstractAuthenticator implements Authentication
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): JsonResponse
     {
+        if ($exception instanceof EmailUnconfirmedException) {
+            return new JsonResponse(
+                ['detail' => $exception->getMessageKey(), 'code' => 'email_unconfirmed'],
+                JsonResponse::HTTP_FORBIDDEN
+            );
+        }
+
         return new JsonResponse(
             ['detail' => 'Invalid credentials'],
             JsonResponse::HTTP_UNAUTHORIZED

--- a/src/App/Security/EmailUnconfirmedException.php
+++ b/src/App/Security/EmailUnconfirmedException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\App\Security;
+
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+
+/**
+ * Thrown by {@see UserConfirmedEmailChecker} when an account still has a pending
+ * email confirmation. A dedicated type lets the API layer map *only* this case to
+ * the stable `email_unconfirmed` code, without mislabeling other future
+ * AccountStatusException causes (e.g. locked/disabled accounts).
+ */
+class EmailUnconfirmedException extends CustomUserMessageAccountStatusException
+{
+}

--- a/src/App/Security/UserConfirmedEmailChecker.php
+++ b/src/App/Security/UserConfirmedEmailChecker.php
@@ -6,7 +6,6 @@ namespace BikeShare\App\Security;
 
 use BikeShare\Event\UserReconfirmationEvent;
 use BikeShare\Repository\RegistrationRepository;
-use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -29,9 +28,11 @@ class UserConfirmedEmailChecker implements UserCheckerInterface
     {
         $confirmation = $this->registrationRepository->findItemByUserId($user->getUserId());
         if (!empty($confirmation)) {
-            $this->eventDispatcher->dispatch(new UserReconfirmationEvent($user));
+            // Carry the userKey read here into the event so the listener never re-queries
+            // (the row may be deleted concurrently by the email-confirmation flow).
+            $this->eventDispatcher->dispatch(new UserReconfirmationEvent($user, (string)$confirmation['userKey']));
 
-            throw new CustomUserMessageAccountStatusException(
+            throw new EmailUnconfirmedException(
                 $this->translator->trans('User does not confirmed email. Check your email for confirmation letter.')
             );
         }

--- a/src/Controller/Api/V1/AuthController.php
+++ b/src/Controller/Api/V1/AuthController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller\Api\V1;
 
+use BikeShare\App\Security\EmailUnconfirmedException;
 use BikeShare\App\Security\JwtTokenService;
 use BikeShare\App\Security\UserConfirmedEmailChecker;
 use BikeShare\App\Security\UserProvider;
@@ -19,7 +20,6 @@ use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
-use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -264,8 +264,11 @@ class AuthController extends AbstractController
     {
         try {
             $this->userConfirmedEmailChecker->checkPostAuth($user);
-        } catch (AccountStatusException $e) {
-            return $this->json(['detail' => $e->getMessageKey()], Response::HTTP_FORBIDDEN);
+        } catch (EmailUnconfirmedException $e) {
+            return $this->json(
+                ['detail' => $e->getMessageKey(), 'code' => 'email_unconfirmed'],
+                Response::HTTP_FORBIDDEN
+            );
         }
 
         return null;

--- a/src/Event/UserReconfirmationEvent.php
+++ b/src/Event/UserReconfirmationEvent.php
@@ -8,12 +8,19 @@ use BikeShare\App\Entity\User;
 
 class UserReconfirmationEvent
 {
-    public function __construct(private readonly User $user)
-    {
+    public function __construct(
+        private readonly User $user,
+        private readonly string $userKey,
+    ) {
     }
 
     public function getUser(): User
     {
         return $this->user;
+    }
+
+    public function getUserKey(): string
+    {
+        return $this->userKey;
     }
 }

--- a/src/EventListener/ReconfirmationEventListener.php
+++ b/src/EventListener/ReconfirmationEventListener.php
@@ -6,7 +6,7 @@ namespace BikeShare\EventListener;
 
 use BikeShare\Event\UserReconfirmationEvent;
 use BikeShare\Mail\MailSenderInterface;
-use BikeShare\Repository\RegistrationRepository;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -14,25 +14,32 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ReconfirmationEventListener
 {
     public function __construct(
-        private readonly RegistrationRepository $registrationRepository,
         private readonly MailSenderInterface $mailSender,
         private readonly TranslatorInterface $translator,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly LoggerInterface $logger,
+        private readonly CacheItemPoolInterface $cache,
     ) {
     }
 
     public function __invoke(UserReconfirmationEvent $event): void
     {
         $user = $event->getUser();
+        $userId = $user->getUserId();
+
+        // Throttle: the email checker runs on every authenticated API request, so an
+        // unconfirmed caller could otherwise trigger one reconfirmation email per request.
+        // Send at most one per user per window regardless of how often the event fires.
+        $throttleItem = $this->cache->getItem('reconfirmation_email.' . $userId);
+        if ($throttleItem->isHit()) {
+            return;
+        }
+        // Expiry comes from the pool's default lifetime (cache.reconfirmation_throttle).
+        $throttleItem->set(true);
+        $this->cache->save($throttleItem);
 
         $subject = $this->translator->trans('Email confirmation');
-
-        $userId = $user->getUserId();
         $emailRecipient = $user->getEmail();
-
-        $registration = $this->registrationRepository->findItemByUserId($userId);
-        $userKey = $registration['userKey'];
 
         $names = preg_split("/[\s,]+/", $user->getUsername());
         $firstName = $names[0];
@@ -42,7 +49,7 @@ class ReconfirmationEventListener
                 'name' => $firstName,
                 'emailConfirmURL' => $this->urlGenerator->generate(
                     'user_confirm_email',
-                    ['key' => $userKey],
+                    ['key' => $event->getUserKey()],
                     UrlGeneratorInterface::ABSOLUTE_URL
                 )
             ]

--- a/tests/Application/Controller/Api/Auth/EmailUnconfirmedFirewallApiTest.php
+++ b/tests/Application/Controller/Api/Auth/EmailUnconfirmedFirewallApiTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Application tests for per-request email-confirmation enforcement on the api_v1 firewall.
+ *
+ * An account with a pending email confirmation (a `registration` token row) must be
+ * rejected with 403 `email_unconfirmed` on Bearer-protected requests, even if a token
+ * was somehow issued; once the email is confirmed the same token passes the check.
+ */
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Controller\Api\Auth;
+
+use BikeShare\App\Security\JwtTokenService;
+use BikeShare\App\Security\UserProvider;
+use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Purifier\PhonePurifierInterface;
+use BikeShare\Repository\RegistrationRepository;
+use BikeShare\Repository\UserRepository;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class EmailUnconfirmedFirewallApiTest extends BikeSharingWebTestCase
+{
+    public function testBearerRequestIsRejectedWhileEmailUnconfirmedThenPassesAfterConfirmation(): void
+    {
+        ['email' => $userEmail, 'phone' => $userPhone, 'password' => $password]
+            = $this->registerUnconfirmedUser('903');
+
+        $container = $this->client->getContainer();
+        $phonePurifier = $container->get(PhonePurifierInterface::class);
+        $purifiedPhone = $phonePurifier->purify($userPhone);
+
+        // Token issuance is blocked while email is unconfirmed, so forge an access token
+        // directly to exercise the per-request firewall check on a Bearer endpoint.
+        $userProvider = $container->get(UserProvider::class);
+        $jwtTokenService = $container->get(JwtTokenService::class);
+        $registrationRepository = $container->get(RegistrationRepository::class);
+        $userRepository = $container->get(UserRepository::class);
+
+        $userRow = $userRepository->findItemByEmail($userEmail);
+        $this->assertNotNull($userRow);
+        $this->assertNotNull(
+            $registrationRepository->findItemByUserId($userRow['userId']),
+            'Freshly registered user must have a pending registration token'
+        );
+
+        $user = $userProvider->loadUserByIdentifier($purifiedPhone);
+        $accessToken = $jwtTokenService->createAccessToken($user)['token'];
+
+        // /user/phone-confirm/request is reachable by ROLE_NEWBIE, so a 403 here isolates
+        // the email UserChecker rather than the phone access-control gate.
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/request',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken]
+        );
+        $this->assertResponseStatusCodeSame(403);
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
+        $problem = $this->decodeJsonResponse();
+        $this->assertSame('email_unconfirmed', $problem['code'] ?? null);
+        $this->assertStringContainsString('email', strtolower((string)($problem['detail'] ?? '')));
+
+        // Confirm the email out-of-band via the link from the registration mail.
+        $mailSender = $container->get(MailSenderInterface::class);
+        $body = $mailSender->getSentMessages()[0]['message'] ?? '';
+        preg_match('/(\/user\/confirm\/email\/[a-z0-9]+)/', (string)$body, $matches);
+        $this->assertNotEmpty($matches[1] ?? null, 'Email confirmation link not found');
+        $this->client->request(Request::METHOD_GET, $matches[1]);
+        $this->assertResponseRedirects();
+        $this->assertNull($registrationRepository->findItemByUserId($userRow['userId']));
+
+        // Same token now passes the email check (phone-confirm allowed for ROLE_NEWBIE).
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/user/phone-confirm/request',
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer ' . $accessToken]
+        );
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testTokenIssuanceStillRejectsEmailUnconfirmed(): void
+    {
+        ['phone' => $userPhone, 'password' => $password] = $this->registerUnconfirmedUser('904');
+
+        $phonePurifier = $this->client->getContainer()->get(PhonePurifierInterface::class);
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/auth/token',
+            ['number' => $phonePurifier->purify($userPhone), 'password' => $password]
+        );
+        $this->assertResponseStatusCodeSame(403);
+        $problem = $this->decodeJsonResponse();
+        $this->assertSame('email_unconfirmed', $problem['code'] ?? null);
+        $this->assertStringContainsString('email', strtolower((string)($problem['detail'] ?? '')));
+    }
+
+    /**
+     * Register a fresh user (email left unconfirmed) and return its credentials.
+     *
+     * @return array{email: string, phone: string, password: string}
+     */
+    private function registerUnconfirmedUser(string $phonePrefix): array
+    {
+        $userEmail = 'email_fw_' . time() . '_' . bin2hex(random_bytes(4)) . '@example.com';
+        $userPhone = '+421' . $phonePrefix . rand(100000, 999999);
+        $password = 'password123';
+
+        $this->client->request(
+            Request::METHOD_POST,
+            '/api/v1/auth/register',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'fullname' => 'Eve Doe',
+                'city' => 'Default City',
+                'useremail' => $userEmail,
+                'password' => $password,
+                'password2' => $password,
+                'number' => $userPhone,
+                'agree' => true,
+            ])
+        );
+        $this->assertResponseStatusCodeSame(201);
+
+        return ['email' => $userEmail, 'phone' => $userPhone, 'password' => $password];
+    }
+}

--- a/tests/Integration/EventListener/ReconfirmationEventListenerTest.php
+++ b/tests/Integration/EventListener/ReconfirmationEventListenerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Integration\EventListener;
+
+use BikeShare\App\Entity\User;
+use BikeShare\Event\UserReconfirmationEvent;
+use BikeShare\Mail\MailSenderInterface;
+use BikeShare\Test\Integration\BikeSharingKernelTestCase;
+
+class ReconfirmationEventListenerTest extends BikeSharingKernelTestCase
+{
+    private const USER_ID = 987654;
+    private const USER_KEY = 'reconfirmkey123';
+
+    public function testReconfirmationEmailUsesEventUserKeyAndIsThrottled(): void
+    {
+        $cache = self::getContainer()->get('cache.reconfirmation_throttle');
+        $cache->deleteItem('reconfirmation_email.' . self::USER_ID);
+
+        $eventDispatcher = self::getContainer()->get('event_dispatcher');
+        $mailSender = self::getContainer()->get(MailSenderInterface::class);
+
+        $event = new UserReconfirmationEvent($this->buildUser(), self::USER_KEY);
+
+        // First dispatch sends the email, building the confirm URL purely from the event's
+        // userKey (no registration re-query — so a concurrently deleted row cannot crash it).
+        $eventDispatcher->dispatch($event);
+        $this->assertCount(1, $mailSender->getSentMessages());
+        $this->assertStringContainsString(self::USER_KEY, $mailSender->getSentMessages()[0]['message']);
+
+        // Second dispatch within the window is throttled — no additional email.
+        $eventDispatcher->dispatch($event);
+        $this->assertCount(1, $mailSender->getSentMessages(), 'Reconfirmation email should be throttled');
+    }
+
+    private function buildUser(): User
+    {
+        return new User(
+            self::USER_ID,
+            '+421900111222',
+            'reconfirm_' . self::USER_ID . '@example.com',
+            'hash',
+            'Default City',
+            'Eve Doe',
+            0,
+            false,
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements [spec 0003](../blob/main/docs/specs/0003-email-verification-firewall.md): email confirmation is now enforced **per Bearer request** on the `api_v1` firewall via the existing `UserConfirmedEmailChecker` — the same `UserChecker` the web (`main`) firewall already uses. Closes the gap where a token issued before an account lapsed kept working on the API until expiry, while the web blocked immediately.

This keeps the email check as a block-at-auth `UserChecker` (the spec's recorded decision) rather than moving it to a `ROLE_NEWBIE`-style role gate — email confirmation is out-of-band, so an authenticated-but-unconfirmed user has no useful in-session action.

## Changes

- **`config/packages/security.php`** — add `->userChecker(UserConfirmedEmailChecker::class)` to the `api_v1` firewall.
- **`ApiV1Authenticator::onAuthenticationFailure`** — map `AccountStatusException` → `403` with a stable `code: email_unconfirmed` (parity with `phone_unconfirmed`); other failures stay `401`.
- **`AuthController`** — the kept `token`/`refresh` manual checks now return the same `code` for a consistent contract.
- **`openapi.yaml`** — generalize the shared `403` response (`PhoneUnconfirmed` → `Forbidden`) documenting both `email_unconfirmed` and `phone_unconfirmed`; add the (previously undocumented) `403` to `/auth/token` and `/auth/refresh`.
- **Application test** — `EmailUnconfirmedFirewallApiTest`: per-request rejection (`403` + `email_unconfirmed` problem+json), pass-through once email is confirmed, and that token issuance still rejects unconfirmed email.

## Acceptance criteria

- [x] `api_v1` rejects email-unconfirmed Bearer requests with `403` + email message.
- [x] `token`/`refresh` still reject email-unconfirmed at issuance (unchanged).
- [x] Web login behaviour unchanged (checker already on `main`).
- [x] `composer test` green — **468 tests, 8161 assertions**.

## Notes / follow-up

- Adds a small per-request `RegistrationRepository` lookup on authenticated API requests (the web firewall already pays this; accepted in the spec).
- ⚠️ Because the checker dispatches `UserReconfirmationEvent` (sends a confirmation email) when email is unconfirmed, that email now fires per rejected Bearer request, not just at login/token/refresh. Worth a follow-up to throttle or scope it; out of this PR's spec.