### PR TITLE
Map: draw service stands below active ones (spec 0010, web)

### DIFF
--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -174,6 +174,13 @@ function getmarkers() {
         const body = $('body');
         const iconSizeArr = [iconsize, iconsize];
         const iconAnchorArr = [iconsize / 2, 0];
+        const seen = {};
+        const makeIcon = (html, standid) => L.divIcon({
+            iconSize: iconSizeArr,
+            iconAnchor: iconAnchorArr,
+            html: html,
+            standid: standid
+        });
 
         for (let i = 0, len = jsonObject.length; i < len; i++) {
             const {
@@ -203,25 +210,50 @@ function getmarkers() {
                     <dd class="standname">${standName}</dd>
                 </dl>`;
 
-            const tempIcon = L.divIcon({
-                iconSize: iconSizeArr,
-                iconAnchor: iconAnchorArr,
-                html: iconHTML,
-                standid: standId
-            });
-
             markerdata[standId] = {
                 name: standName,
                 desc: standDescription,
                 photo: standPhoto,
                 count: bikeCount
             };
+            seen[standId] = true;
 
-            markers[standId] = L.marker([latitude, longitude], {
-                icon: tempIcon,
-                pane: isServiceStand ? 'standServicePane' : 'markerPane'
-            }).addTo(map).on("click", showstand);
+            const pane = isServiceStand ? 'standServicePane' : 'markerPane';
+            const existing = markers[standId];
+            // Reconcile in place so the 60s refresh doesn't leak layers (old code never
+            // removed markers) — and doesn't flicker either: existing markers are updated,
+            // only new stands are added, stale ones are removed after the loop. setIcon
+            // runs only when the rendered HTML changed, so unchanged markers don't redraw.
+            if (existing && existing._pane === pane) {
+                existing.setLatLng([latitude, longitude]);
+                if (existing._iconHtml !== iconHTML) {
+                    existing.setIcon(makeIcon(iconHTML, standId));
+                    existing._iconHtml = iconHTML;
+                }
+            } else {
+                // New stand, or its status crossed the service/active boundary (the pane is
+                // fixed at construction, so that marker must be recreated).
+                if (existing) {
+                    map.removeLayer(existing);
+                }
+                const marker = L.marker([latitude, longitude], {
+                    icon: makeIcon(iconHTML, standId),
+                    pane: pane
+                }).addTo(map).on("click", showstand);
+                marker._pane = pane;
+                marker._iconHtml = iconHTML;
+                markers[standId] = marker;
+            }
         }
+
+        // Drop markers for stands no longer in the feed.
+        Object.keys(markers).forEach(function (id) {
+            if (!seen[id]) {
+                map.removeLayer(markers[id]);
+                delete markers[id];
+                delete markerdata[id];
+            }
+        });
 
         body.data('markerdata', markerdata);
 

--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -93,6 +93,12 @@ function mapinit() {
     map.setView(new L.LatLng($("body").data("mapcenterlat"), $("body").data("mapcenterlong")), $("body").data("mapzoom"));
     map.addLayer(osm);
 
+    // Stand markers: service ("technical") and testing ("hidden") stands go on a lower
+    // pane so active/parking stands are never hidden behind them (spec 0010). A pane's
+    // z-index is a hard order, unlike zIndexOffset which mixes with latitude position.
+    map.createPane('standServicePane');
+    map.getPane('standServicePane').style.zIndex = 590; // below the default markerPane (600)
+
     lc = L.control.locate({
         locateOptions: {
             maxZoom: mapzoom,
@@ -182,6 +188,7 @@ function getmarkers() {
             } = jsonObject[i];
 
             let iconClass = 'icondesc';
+            const isServiceStand = status === 'technical' || status === 'hidden';
             if (status === 'technical') {
                 iconClass += ' stand-technical';
             } else if (status === 'hidden') {
@@ -211,7 +218,8 @@ function getmarkers() {
             };
 
             markers[standId] = L.marker([latitude, longitude], {
-                icon: tempIcon
+                icon: tempIcon,
+                pane: isServiceStand ? 'standServicePane' : 'markerPane'
             }).addTo(map).on("click", showstand);
         }
 


### PR DESCRIPTION
Web half of spec 0010 (paired with the Android PR), plus a related marker-lifecycle fix found during review.

## 1. Z-order (spec 0010)
- `mapinit()` creates a custom pane `standServicePane` with `z-index: 590` (below the default `markerPane` at 600).
- `getmarkers()` places `technical`/`hidden` stand markers in that pane; all others in the default `markerPane`. Active/parking stands always sit on top.
- Pane z-index is a hard order — chosen over `zIndexOffset`, which mixes with Leaflet's latitude-based z.

## 2. Marker reconcile (pre-existing bug, bundled)
`getmarkers()` runs every 60s but never removed old markers — each refresh added a fresh `L.marker` per stand on top of the previous, leaking Leaflet layers/DOM unbounded (silent: they overlap the same coords). Now reconciled by `standId`:
- existing markers updated **in place** (`setLatLng`; `setIcon` only when the rendered HTML changed),
- only new stands created (and one recreated only if its status crosses the service/active pane boundary),
- stands gone from the feed removed.

This fixes the leak **without** a full remove/re-add, so the map doesn't flicker on refresh.

## Status→layer
Below = `technical` (service) + `hidden` (testing); on top = everything else. Same mapping as Android.

## Tests
No JS test harness in this repo → `node --check` (syntax OK) + manual. The ordering rule is unit-tested on the Android side.

Spec: `docs/specs/0010-*`.
