### PR TITLE
fix(users): return 0 instead of null credit for users with no credit row

### DIFF
--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -22,7 +22,7 @@ class UserRepository
                 mail,
                 number,
                 privileges,
-                credit,
+                COALESCE(credit.credit, 0) AS credit,
                 userLimit,
                 isNumberConfirmed,
                 registrationDate
@@ -44,7 +44,7 @@ class UserRepository
                 mail,
                 number,
                 privileges,
-                credit,
+                COALESCE(credit.credit, 0) AS credit,
                 userLimit,
                 isNumberConfirmed,
                 registrationDate
@@ -69,7 +69,7 @@ class UserRepository
                 mail,
                 number,
                 privileges,
-                credit,
+                COALESCE(credit.credit, 0) AS credit,
                 userLimit,
                 isNumberConfirmed,
                 registrationDate
@@ -94,7 +94,7 @@ class UserRepository
                 mail,
                 number,
                 privileges,
-                credit,
+                COALESCE(credit.credit, 0) AS credit,
                 userLimit,
                 isNumberConfirmed,
                 registrationDate

--- a/tests/Application/Flow/CreditInitOnRegistrationTest.php
+++ b/tests/Application/Flow/CreditInitOnRegistrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Application\Flow;
+
+use BikeShare\Repository\UserRepository;
+use BikeShare\Test\Application\BikeSharingWebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class CreditInitOnRegistrationTest extends BikeSharingWebTestCase
+{
+    public function testNewUserCreditIsZeroAfterRegistration(): void
+    {
+        $userEmail = 'credit_init_test_' . uniqid() . '@example.com';
+        $userPhone = '+421901' . rand(100000, 999999);
+
+        $this->client->request(Request::METHOD_GET, '/register');
+        $this->assertResponseIsSuccessful();
+
+        $this->client->submitForm('register', [
+            'registration_form[fullname]' => 'Jane Doe',
+            'registration_form[city]' => 'Default City',
+            'registration_form[useremail]' => $userEmail,
+            'registration_form[password]' => 'password123',
+            'registration_form[password2]' => 'password123',
+            'registration_form[number]' => $userPhone,
+            'registration_form[agree]' => '1',
+        ]);
+        $this->assertResponseRedirects('/');
+
+        $user = static::getContainer()->get(UserRepository::class)->findItemByEmail($userEmail);
+        $this->assertNotNull($user);
+        $this->assertSame(0.0, (float) $user['credit']);
+    }
+}


### PR DESCRIPTION
## Summary

- `UserRepository` SELECT queries used `LEFT JOIN credit` which returned `NULL` for users who never had a credit transaction (no admin top-up, no deduction)
- Replace bare `credit` column reference with `COALESCE(credit.credit, 0) AS credit` in all four user fetch methods (`findAll`, `findItem`, `findItemByPhoneNumber`, `findItemByEmail`)
- No schema migration needed — existing `NULL` rows are handled at query level; no new rows are inserted at registration

## Test plan

- [x] `CreditInitOnRegistrationTest` — registers a user via the web form and asserts `credit = 0.0` is returned by `UserRepository::findItemByEmail`
- [x] `composer test` green (480 tests)